### PR TITLE
Playlist fixes and playable playlist listboxes

### DIFF
--- a/OsuPlayer/Views/PlaylistEditorView.axaml
+++ b/OsuPlayer/Views/PlaylistEditorView.axaml
@@ -163,7 +163,7 @@
 
                 <ListBox Grid.Row="1" Background="Transparent" SelectionMode="Multiple, Toggle"
                          Items="{Binding SongList}" SelectedItems="{Binding SelectedSongListItems}"
-                         SelectionChanged="SongList_OnSelectionChanged">
+                         SelectionChanged="SongList_OnSelectionChanged" DoubleTapped="PlaySong">
                     <ListBox.ItemTemplate>
                         <DataTemplate DataType="dataModels:IMapEntryBase">
                             <Grid>
@@ -194,7 +194,7 @@
 
                 <ListBox Grid.Row="1" Background="Transparent" SelectionMode="Multiple, Toggle"
                          Items="{Binding CurrentSelectedPlaylist.Songs, Converter={StaticResource PlaylistValueConverter}}"
-                         SelectionChanged="Playlist_OnSelectionChanged">
+                         SelectionChanged="Playlist_OnSelectionChanged" DoubleTapped="PlaySong">
                     <ListBox.ItemTemplate>
                         <DataTemplate DataType="dataModels:IMapEntryBase">
                             <Grid>

--- a/OsuPlayer/Views/PlaylistEditorView.axaml.cs
+++ b/OsuPlayer/Views/PlaylistEditorView.axaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.VisualTree;
@@ -97,7 +98,7 @@ public partial class PlaylistEditorView : ReactivePlayerControl<PlaylistEditorVi
     {
         if (ViewModel == default) return;
 
-        var listBox = (ListBox)sender!;
+        var listBox = (ListBox) sender!;
 
         var songs = listBox.SelectedItems.Cast<IMapEntryBase>().ToList();
 
@@ -108,7 +109,7 @@ public partial class PlaylistEditorView : ReactivePlayerControl<PlaylistEditorVi
     {
         if (ViewModel == default) return;
 
-        var listBox = (ListBox)sender!;
+        var listBox = (ListBox) sender!;
 
         var songs = listBox.SelectedItems.Cast<IMapEntryBase>().ToList();
 
@@ -195,5 +196,14 @@ public partial class PlaylistEditorView : ReactivePlayerControl<PlaylistEditorVi
         if (ViewModel == default) return;
 
         ViewModel.IsDeletePlaylistPopupOpen = false;
+    }
+
+    private async void PlaySong(object? sender, RoutedEventArgs e)
+    {
+        var tapped = (TappedEventArgs) e;
+        var controlSource = (Control) tapped.Pointer.Captured;
+
+        if (controlSource?.DataContext is IMapEntryBase song)
+            await ViewModel.Player.PlayAsync(song);
     }
 }

--- a/OsuPlayer/Views/PlaylistEditorViewModel.cs
+++ b/OsuPlayer/Views/PlaylistEditorViewModel.cs
@@ -18,9 +18,6 @@ public class PlaylistEditorViewModel : BaseViewModel
     private bool _isRenamePlaylistPopupOpen;
     private string _newPlaylistNameText;
     private SourceList<Playlist>? _playlists;
-    private List<IMapEntryBase>? _selectedPlaylistItems;
-
-    private List<IMapEntryBase>? _selectedSongListItems;
 
     public PlaylistEditorViewModel(Player player)
     {
@@ -77,15 +74,7 @@ public class PlaylistEditorViewModel : BaseViewModel
 
     public List<IMapEntryBase> SongList => _player.SongSourceList!;
 
-    public List<IMapEntryBase>? SelectedSongListItems
-    {
-        get => _selectedSongListItems;
-        set => this.RaiseAndSetIfChanged(ref _selectedSongListItems, value);
-    }
+    public List<IMapEntryBase>? SelectedSongListItems { get; set; }
 
-    public List<IMapEntryBase>? SelectedPlaylistItems
-    {
-        get => _selectedPlaylistItems;
-        set => this.RaiseAndSetIfChanged(ref _selectedPlaylistItems, value);
-    }
+    public List<IMapEntryBase>? SelectedPlaylistItems { get; set; }
 }

--- a/OsuPlayer/Views/PlaylistEditorViewModel.cs
+++ b/OsuPlayer/Views/PlaylistEditorViewModel.cs
@@ -11,7 +11,7 @@ namespace OsuPlayer.Views;
 
 public class PlaylistEditorViewModel : BaseViewModel
 {
-    private readonly Player _player;
+    public readonly Player Player;
     private Playlist? _currentSelectedPlaylist;
     private bool _isDeletePlaylistPopupOpen;
     private bool _isNewPlaylistPopupOpen;
@@ -21,7 +21,7 @@ public class PlaylistEditorViewModel : BaseViewModel
 
     public PlaylistEditorViewModel(Player player)
     {
-        _player = player;
+        Player = player;
 
         Activator = new ViewModelActivator();
 
@@ -72,7 +72,7 @@ public class PlaylistEditorViewModel : BaseViewModel
         set => this.RaiseAndSetIfChanged(ref _playlists, value);
     }
 
-    public List<IMapEntryBase> SongList => _player.SongSourceList!;
+    public List<IMapEntryBase> SongList => Player.SongSourceList!;
 
     public List<IMapEntryBase>? SelectedSongListItems { get; set; }
 

--- a/OsuPlayer/Views/PlaylistView.axaml
+++ b/OsuPlayer/Views/PlaylistView.axaml
@@ -12,7 +12,7 @@
     <Design.DataContext>
         <views:PlaylistViewModel />
     </Design.DataContext>
-    
+
     <UserControl.Resources>
         <valueConverters:PlaylistValueConverter x:Key="PlaylistValueConverter" />
     </UserControl.Resources>
@@ -64,7 +64,8 @@
             </Panel>
 
             <ListBox Background="Transparent"
-                     Items="{Binding SelectedPlaylist.Songs, Converter={StaticResource PlaylistValueConverter}}">
+                     Items="{Binding SelectedPlaylist.Songs, Converter={StaticResource PlaylistValueConverter}}"
+                     DoubleTapped="PlaySong">
                 <ListBox.ItemTemplate>
                     <DataTemplate DataType="dataModels:IMapEntryBase">
                         <Grid ColumnDefinitions="*, Auto" RowDefinitions="Auto, Auto">

--- a/OsuPlayer/Views/PlaylistView.axaml.cs
+++ b/OsuPlayer/Views/PlaylistView.axaml.cs
@@ -1,7 +1,10 @@
-﻿using Avalonia.Interactivity;
+﻿using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.VisualTree;
 using OsuPlayer.Extensions;
+using OsuPlayer.IO.DbReader.DataModels;
 using OsuPlayer.IO.Storage.Playlists;
 using OsuPlayer.Windows;
 using ReactiveUI;
@@ -34,5 +37,14 @@ public partial class PlaylistView : ReactivePlayerControl<PlaylistViewModel>
         _mainWindow.ViewModel!.PlaylistEditorViewModel.Playlists = playlists.ToSourceList();
 
         _mainWindow.ViewModel!.MainView = _mainWindow.ViewModel.PlaylistEditorViewModel;
+    }
+
+    private async void PlaySong(object? sender, RoutedEventArgs e)
+    {
+        var tapped = (TappedEventArgs) e;
+        var controlSource = (Control) tapped.Pointer.Captured;
+
+        if (controlSource?.DataContext is IMapEntryBase song)
+            await ViewModel.Player.PlayAsync(song);
     }
 }

--- a/OsuPlayer/Views/PlaylistViewModel.cs
+++ b/OsuPlayer/Views/PlaylistViewModel.cs
@@ -12,28 +12,28 @@ namespace OsuPlayer.Views;
 
 public class PlaylistViewModel : BaseViewModel
 {
+    public readonly Player Player;
     private ObservableCollection<Playlist> _playlists;
-    private readonly Player _player;
 
     public PlaylistViewModel(Player player)
     {
         Activator = new ViewModelActivator();
 
-        _player = player;
+        Player = player;
 
-        _player.PlaylistChanged += (sender, args) =>
+        Player.PlaylistChanged += (sender, args) =>
         {
-            var selection = _player.SelectedPlaylist.Value;
+            var selection = Player.SelectedPlaylist.Value;
 
             if (selection == default)
                 return;
-            
+
             Playlists = PlaylistManager.GetAllPlaylists().ToObservableCollection();
-            
+
             this.RaisePropertyChanged(nameof(Playlists));
-            
-            _player.SelectedPlaylist.Value = Playlists.First(x => x.Id == selection!.Id);
-            
+
+            Player.SelectedPlaylist.Value = Playlists.First(x => x.Id == selection!.Id);
+
             this.RaisePropertyChanged(nameof(SelectedPlaylist));
         };
 
@@ -60,11 +60,11 @@ public class PlaylistViewModel : BaseViewModel
 
     public Playlist? SelectedPlaylist
     {
-        get => _player.SelectedPlaylist.Value;
+        get => Player.SelectedPlaylist.Value;
         set
         {
             PlaylistManager.SetCurrentPlaylist(value);
-            _player.SelectedPlaylist.Value = value;
+            Player.SelectedPlaylist.Value = value;
             this.RaisePropertyChanged();
         }
     }

--- a/OsuPlayer/Views/PlaylistViewModel.cs
+++ b/OsuPlayer/Views/PlaylistViewModel.cs
@@ -13,9 +13,7 @@ namespace OsuPlayer.Views;
 public class PlaylistViewModel : BaseViewModel
 {
     private ObservableCollection<Playlist> _playlists;
-    private Playlist _selectedPlaylist;
     private readonly Player _player;
-
 
     public PlaylistViewModel(Player player)
     {

--- a/OsuPlayer/Views/ReactivePlayerControl.cs
+++ b/OsuPlayer/Views/ReactivePlayerControl.cs
@@ -6,18 +6,17 @@ using ReactiveUI;
 
 namespace OsuPlayer.Views;
 
-public class ReactivePlayerControl<TViewModel> : UserControl, IViewFor<TViewModel> where TViewModel : BaseViewModel
+public class ReactivePlayerControl<TViewModel> : UserControl, IViewFor<TViewModel> where TViewModel : class
 {
     public static readonly StyledProperty<TViewModel> ViewModelProperty = AvaloniaProperty
         .Register<ReactivePlayerControl<TViewModel>, TViewModel>(nameof(ViewModel));
 
     public ReactivePlayerControl()
     {
-        this.WhenActivated(disposables => { ViewModel!.Activator.Activate(); });
+        this.WhenActivated(disposables => { });
         var x = this.GetObservable(ViewModelProperty);
         x.Subscribe(OnViewModelChanged);
     }
-
 
     object? IViewFor.ViewModel
     {
@@ -25,7 +24,11 @@ public class ReactivePlayerControl<TViewModel> : UserControl, IViewFor<TViewMode
         set => SetValue(ViewModelProperty, value);
     }
 
-    public TViewModel ViewModel { get; set; }
+    public TViewModel ViewModel
+    {
+        get => GetValue(ViewModelProperty);
+        set => SetValue(ViewModelProperty, value);
+    }
 
     protected override void OnDataContextChanged(EventArgs e)
     {


### PR DESCRIPTION
Will be needed for #41 as playlist views are currently broken.

Fixes: 
- crash on song deselect in playlist editor caused by stack overflow
- playlists do not update properly when edited because of viewmodel activation issue

Also adds the ability to double tap songs in the playlist view and editor to directly play them.
