### PR TITLE
Display patchnotes

### DIFF
--- a/OsuPlayer.Network/GitHubUpdater.cs
+++ b/OsuPlayer.Network/GitHubUpdater.cs
@@ -43,7 +43,7 @@ public static class GitHubUpdater
         return releases.FirstOrDefault(x => x.Prerelease == includPreReleases);
     }
 
-    public static async Task<string> GetLatestPatchnotes(bool includePreReleases = false)
+    public static async Task<string> GetLatestPatchNotes(bool includePreReleases = false)
     {
         var release = await GetLatestRelease(includePreReleases);
 

--- a/OsuPlayer.Network/GitHubUpdater.cs
+++ b/OsuPlayer.Network/GitHubUpdater.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Globalization;
+using System.Reflection;
 using Octokit;
 
 namespace OsuPlayer.Network;
@@ -40,5 +41,19 @@ public static class GitHubUpdater
         var releases = await github.Repository.Release.GetAll("Founntain", "osuplayer");
 
         return releases.FirstOrDefault(x => x.Prerelease == includPreReleases);
+    }
+
+    public static async Task<string> GetLatestPatchnotes(bool includePreReleases = false)
+    {
+        var release = await GetLatestRelease(includePreReleases);
+
+        if (release == default)
+            return "**No patch-notes found**";
+
+        return $"## {(release.Prerelease ? "pre-release" : "release")} v" + release.TagName + Environment.NewLine 
+               +"*released " + release.CreatedAt.ToString("F", new CultureInfo("en-us")) + "*"
+               + Environment.NewLine 
+               + Environment.NewLine 
+               + release.Body;
     }
 }

--- a/OsuPlayer/OsuPlayer.csproj
+++ b/OsuPlayer/OsuPlayer.csproj
@@ -18,39 +18,40 @@
         <Prefer32bit>true</Prefer32bit>
     </PropertyGroup>
     <ItemGroup>
-        <None Remove=".gitignore"/>
+        <None Remove=".gitignore" />
     </ItemGroup>
     <ItemGroup>
         <!--This helps with theme dll-s trimming.
         If you will publish your application in self-contained mode with p:PublishTrimmed=true and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
         https://github.com/AvaloniaUI/Avalonia/issues/5593 -->
-        <TrimmableAssembly Include="Avalonia.Themes.Fluent"/>
-        <TrimmableAssembly Include="Avalonia.Themes.Default"/>
+        <TrimmableAssembly Include="Avalonia.Themes.Fluent" />
+        <TrimmableAssembly Include="Avalonia.Themes.Default" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="0.10.13"/>
-        <PackageReference Include="Avalonia.Desktop" Version="0.10.13"/>
-        <PackageReference Include="Avalonia.Diagnostics" Version="0.10.13"/>
-        <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.13"/>
-        <PackageReference Include="Avalonia.Skia" Version="0.10.13"/>
-        <PackageReference Include="Founntain.OsuPlayer.NativeLibs" Version="1.0.4"/>
-        <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-beta.101"/>
+        <PackageReference Include="Avalonia" Version="0.10.13" />
+        <PackageReference Include="Avalonia.Desktop" Version="0.10.13" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="0.10.13" />
+        <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.13" />
+        <PackageReference Include="Avalonia.Skia" Version="0.10.13" />
+        <PackageReference Include="Founntain.OsuPlayer.NativeLibs" Version="1.0.4" />
+        <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-beta.101" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Include="ManagedBass" Version="3.1.0"/>
-        <PackageReference Include="ManagedBass.Fx" Version="3.1.0"/>
-        <PackageReference Include="Material.Icons.Avalonia" Version="1.0.2"/>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
-        <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4"/>
+        <PackageReference Include="ManagedBass" Version="3.1.0" />
+        <PackageReference Include="ManagedBass.Fx" Version="3.1.0" />
+        <PackageReference Include="Markdown.Avalonia" Version="0.10.11" />
+        <PackageReference Include="Material.Icons.Avalonia" Version="1.0.2" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
     </ItemGroup>
     <ItemGroup>
-        <Folder Include="Resources"/>
-        <AvaloniaResource Include="Resources\**"/>
+        <Folder Include="Resources" />
+        <AvaloniaResource Include="Resources\**" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\OsuPlayer.Data\OsuPlayer.Data.csproj"/>
-        <ProjectReference Include="..\OsuPlayer.Extensions\OsuPlayer.Extensions.csproj"/>
-        <ProjectReference Include="..\OsuPlayer.IO\OsuPlayer.IO.csproj"/>
-        <ProjectReference Include="..\OsuPlayer.Network\OsuPlayer.Network.csproj"/>
+        <ProjectReference Include="..\OsuPlayer.Data\OsuPlayer.Data.csproj" />
+        <ProjectReference Include="..\OsuPlayer.Extensions\OsuPlayer.Extensions.csproj" />
+        <ProjectReference Include="..\OsuPlayer.IO\OsuPlayer.IO.csproj" />
+        <ProjectReference Include="..\OsuPlayer.Network\OsuPlayer.Network.csproj" />
     </ItemGroup>
     <ItemGroup>
         <Compile Update="Windows\MainWindow.axaml.cs">

--- a/OsuPlayer/Views/SettingsView.axaml
+++ b/OsuPlayer/Views/SettingsView.axaml
@@ -5,6 +5,8 @@
              xmlns:views="clr-namespace:OsuPlayer.Views"
              xmlns:valueConverters="clr-namespace:OsuPlayer.Extensions.ValueConverters;assembly=OsuPlayer.Extensions"
              xmlns:controls="clr-namespace:OsuPlayer.Controls"
+             xmlns:avalonia="clr-namespace:Markdown.Avalonia;assembly=Markdown.Avalonia"
+             xmlns:ctxt="clr-namespace:ColorTextBlock.Avalonia;assembly=ColorTextBlock.Avalonia"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="OsuPlayer.Views.SettingsView"
              Initialized="SettingsView_OnInitialized">
@@ -119,9 +121,36 @@
 
                         <StackPanel Spacing="5" Name="EqualizerSettings">
                             <TextBlock Text="Equalizer settings" />
-                            <Button Content="open eq" Click="OpenEqClick" HorizontalAlignment="Stretch"
+                            <Button Content="open equalizer" Click="OpenEqClick" HorizontalAlignment="Stretch"
                                     HorizontalContentAlignment="Center" />
                         </StackPanel>
+                    </StackPanel>
+                </Grid>
+                
+                <Grid RowDefinitions="Auto" Margin="10" Name="PatchnotesSettings">
+                    <Panel HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                        <ExperimentalAcrylicBorder IsHitTestVisible="False">
+                            <ExperimentalAcrylicBorder.Material>
+                                <ExperimentalAcrylicMaterial
+                                    BackgroundSource="Digger"
+                                    TintColor="Black"
+                                    TintOpacity="1"
+                                    MaterialOpacity="0.75" />
+                            </ExperimentalAcrylicBorder.Material>
+                        </ExperimentalAcrylicBorder>
+                    </Panel>
+                    
+                    <StackPanel Margin="10" Spacing="10" Name="PatchnotesPanel">
+                        <TextBlock Text="Patch-notes" FontSize="32" VerticalAlignment="Center"
+                                   HorizontalAlignment="Stretch" />
+
+                        <avalonia:MarkdownScrollViewer Markdown="{Binding Patchnotes}">
+                            <avalonia:MarkdownScrollViewer.Styles>
+                                <Style Selector="ctxt|CTextBlock.Heading2">
+                                    <Setter Property="Foreground" Value="White"/>
+                                </Style>
+                            </avalonia:MarkdownScrollViewer.Styles>
+                        </avalonia:MarkdownScrollViewer>
                     </StackPanel>
                 </Grid>
             </controls:CascadingWrapPanel>

--- a/OsuPlayer/Views/SettingsViewModel.cs
+++ b/OsuPlayer/Views/SettingsViewModel.cs
@@ -8,6 +8,7 @@ using OsuPlayer.Data.OsuPlayer.Classes;
 using OsuPlayer.Data.OsuPlayer.Enums;
 using OsuPlayer.IO.Storage.Config;
 using OsuPlayer.Modules.Audio;
+using OsuPlayer.Network;
 using OsuPlayer.Network.Online;
 using OsuPlayer.ViewModels;
 using OsuPlayer.Windows;
@@ -24,6 +25,13 @@ public class SettingsViewModel : BaseViewModel
     private string _settingsSearchQ;
 
     public MainWindow? MainWindow;
+    private string _patchnotes;
+
+    public string Patchnotes
+    {
+        get => _patchnotes;
+        set => this.RaiseAndSetIfChanged(ref _patchnotes, value);
+    }
 
     public SettingsViewModel(Player player)
     {
@@ -35,7 +43,14 @@ public class SettingsViewModel : BaseViewModel
         Player = player;
 
         Activator = new ViewModelActivator();
-        this.WhenActivated(disposables => { Disposable.Create(() => { }).DisposeWith(disposables); });
+        this.WhenActivated(Block);
+    }
+
+    private async void Block(CompositeDisposable disposables)
+    {
+        Disposable.Create(() => { }).DisposeWith(disposables);
+
+        Patchnotes = await GitHubUpdater.GetLatestPatchnotes(true);
     }
 
     public User? CurrentUser => ProfileManager.User;

--- a/OsuPlayer/Views/SettingsViewModel.cs
+++ b/OsuPlayer/Views/SettingsViewModel.cs
@@ -55,6 +55,8 @@ public class SettingsViewModel : BaseViewModel
         var latestPatchNotes = await GitHubUpdater.GetLatestPatchNotes(true);
 
         var regex = new Regex(@"( in )([\w\s:\/\.])*[\d]+");
+        latestPatchNotes = regex.Replace(latestPatchNotes, "");
+        regex = new Regex(@"(\n?\r?)*[\*]*(Full Changelog)[\*]*:.*$");
         Patchnotes = regex.Replace(latestPatchNotes, "");
     }
 

--- a/OsuPlayer/Views/SettingsViewModel.cs
+++ b/OsuPlayer/Views/SettingsViewModel.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive.Disposables;
+using System.Text.RegularExpressions;
 using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
 using OsuPlayer.Data.OsuPlayer.Classes;
 using OsuPlayer.Data.OsuPlayer.Enums;
 using OsuPlayer.IO.Storage.Config;
@@ -50,7 +52,10 @@ public class SettingsViewModel : BaseViewModel
     {
         Disposable.Create(() => { }).DisposeWith(disposables);
 
-        Patchnotes = await GitHubUpdater.GetLatestPatchnotes(true);
+        var latestPatchNotes = await GitHubUpdater.GetLatestPatchNotes(true);
+
+        var regex = new Regex(@"( in )([\w\s:\/\.])*[\d]+");
+        Patchnotes = regex.Replace(latestPatchNotes, "");
     }
 
     public User? CurrentUser => ProfileManager.User;


### PR DESCRIPTION
This will close #39 

Currently the patchnotes will **always** include pre-releases.
This will change when we implemented the ability to switch between release channels *(release or pre-release)*