### PR TITLE
Fix playlist song duplication

### DIFF
--- a/OsuPlayer.Data/OsuPlayer/Classes/Playlist.cs
+++ b/OsuPlayer.Data/OsuPlayer/Classes/Playlist.cs
@@ -5,7 +5,8 @@
 namespace OsuPlayer.Data.OsuPlayer.Classes;
 
 /// <summary>
-/// A playlist object containing an <see cref="Id"/>, the <see cref="Name"/>, the <see cref="CreationTime"/> and a <see cref="Songs"/> list
+/// A playlist object containing an <see cref="Id" />, the <see cref="Name" />, the <see cref="CreationTime" /> and a
+/// <see cref="Songs" /> list
 /// </summary>
 public class Playlist
 {
@@ -14,9 +15,9 @@ public class Playlist
     public DateTime CreationTime { get; set; } = DateTime.UtcNow;
 
     /// <summary>
-    /// Contains the beatmap set ids of the songs in the <see cref="Playlist"/>
+    /// Contains the hashes of the songs in the <see cref="Playlist" />
     /// </summary>
-    public BindingList<int> Songs { get; set; } = new();
+    public BindingList<string> Songs { get; set; } = new();
 
     private bool Equals(Playlist other)
     {

--- a/OsuPlayer.IO/DbReader/DataModels/DbMapEntry.cs
+++ b/OsuPlayer.IO/DbReader/DataModels/DbMapEntry.cs
@@ -7,9 +7,9 @@ namespace OsuPlayer.IO.DbReader.DataModels;
 
 /// <summary>
 /// a full beatmap entry with optionally used data
-/// <remarks>only created on a <see cref="OsuDbReader.ReadFullMapEntry" /> call</remarks>
+/// <remarks>only created on a <see cref="IMapEntryBase.ReadFullEntry" /> call</remarks>
 /// </summary>
-public class DbMapEntry : DbMapEntryBase, IMapEntry
+internal class DbMapEntry : DbMapEntryBase, IMapEntry
 {
     public string ArtistUnicode { get; set; }
     public string TitleUnicode { get; set; }
@@ -109,13 +109,13 @@ public class DbMapEntry : DbMapEntryBase, IMapEntry
 
     public override bool Equals(object? obj)
     {
-        if (obj is DbMapEntry other) return BeatmapChecksum == other.BeatmapChecksum;
+        if (obj is DbMapEntry other) return Hash == other.Hash;
 
         return false;
     }
 
     public override int GetHashCode()
     {
-        return BitConverter.ToInt32(Encoding.UTF8.GetBytes(BeatmapChecksum));
+        return BitConverter.ToInt32(Encoding.UTF8.GetBytes(Hash));
     }
 }

--- a/OsuPlayer.IO/DbReader/DataModels/DbMapEntryBase.cs
+++ b/OsuPlayer.IO/DbReader/DataModels/DbMapEntryBase.cs
@@ -11,7 +11,7 @@ public class DbMapEntryBase : IMapEntryBase
     public long DbOffset { get; set; }
     public string Artist { get; set; } = string.Empty;
     public string Title { get; set; } = string.Empty;
-    public string BeatmapChecksum { get; set; } = string.Empty;
+    public string Hash { get; set; } = string.Empty;
     public int BeatmapSetId { get; set; }
     public int TotalTime { get; set; }
     public string TotalTimeString => TimeSpan.FromMilliseconds(TotalTime).FormatTime();
@@ -90,7 +90,7 @@ public class DbMapEntryBase : IMapEntryBase
         r.ReadString(true); //Difficulty
 
         mapEntry.AudioFileName = r.ReadString();
-        mapEntry.BeatmapChecksum = r.ReadString();
+        mapEntry.Hash = r.ReadString();
 
         r.ReadString(true); //BeatmapFileName
         r.ReadByte(); //RankedStatus

--- a/OsuPlayer.IO/DbReader/DataModels/IMapEntryBase.cs
+++ b/OsuPlayer.IO/DbReader/DataModels/IMapEntryBase.cs
@@ -6,7 +6,7 @@ public interface IMapEntryBase
 {
     public string Artist { get; set; }
     public string Title { get; set; }
-    public string BeatmapChecksum { get; set; }
+    public string Hash { get; set; }
     public int BeatmapSetId { get; set; }
     public int TotalTime { get; set; }
     public string TotalTimeString => TimeSpan.FromMilliseconds(TotalTime).FormatTime();

--- a/OsuPlayer.IO/DbReader/DataModels/RealmMapEntry.cs
+++ b/OsuPlayer.IO/DbReader/DataModels/RealmMapEntry.cs
@@ -4,7 +4,11 @@ using Avalonia.Platform;
 
 namespace OsuPlayer.IO.DbReader.DataModels;
 
-public class RealmMapEntry : RealmMapEntryBase, IMapEntry
+/// <summary>
+/// a full beatmap entry with optionally used data
+/// <remarks>only created on a <see cref="IMapEntryBase.ReadFullEntry" /> call</remarks>
+/// </summary>
+internal class RealmMapEntry : RealmMapEntryBase, IMapEntry
 {
     public string BackgroundFileLocation { get; set; }
     public string ArtistUnicode { get; set; }

--- a/OsuPlayer.IO/DbReader/DataModels/RealmMapEntryBase.cs
+++ b/OsuPlayer.IO/DbReader/DataModels/RealmMapEntryBase.cs
@@ -4,12 +4,16 @@ using Realms;
 
 namespace OsuPlayer.IO.DbReader.DataModels;
 
+/// <summary>
+/// a minimal beatmap entry with only frequently used data
+/// <remarks>created on call of <see cref="RealmReader.Read(string)" /></remarks>
+/// </summary>
 public class RealmMapEntryBase : IMapEntryBase
 {
     public Guid Id { get; set; }
     public string Artist { get; set; }
     public string Title { get; set; }
-    public string BeatmapChecksum { get; set; }
+    public string Hash { get; set; }
     public int BeatmapSetId { get; set; }
     public int TotalTime { get; set; }
     public string TotalTimeString => TimeSpan.FromMilliseconds(TotalTime).FormatTime();
@@ -63,7 +67,7 @@ public class RealmMapEntryBase : IMapEntryBase
             TitleUnicode = beatmap.Metadata.TitleUnicode,
             AudioFileName = beatmap.Metadata.AudioFile,
             BackgroundFileLocation = string.IsNullOrEmpty(backgroundFolderName) ? string.Empty : Path.Combine(path, "files", backgroundFolderName, backgroundFile!.File.Hash),
-            BeatmapChecksum = BeatmapChecksum,
+            Hash = Hash,
             BeatmapSetId = beatmap.OnlineID,
             FolderName = audioFolderName,
             FolderPath = Path.Combine("files", audioFolderName),

--- a/OsuPlayer.IO/DbReader/OsuDbReader.cs
+++ b/OsuPlayer.IO/DbReader/OsuDbReader.cs
@@ -83,7 +83,10 @@ public class OsuDbReader : BinaryReader
     /// Reads all difficulties from the osu!.db with hashes and set ids
     /// </summary>
     /// <param name="osuPath">the osu! root path where the osu!.db is located</param>
-    /// <returns>a <see cref="Dictionary{TKey,TValue}"/> where the <b>TKey</b> is the beatmap hash and the <b>TValue</b> is the set id</returns>
+    /// <returns>
+    /// a <see cref="Dictionary{TKey,TValue}" /> where the <b>TKey</b> is the beatmap hash and the <b>TValue</b> is
+    /// the set id
+    /// </returns>
     public static async Task<Dictionary<string, int>?> ReadAllDiffs(string osuPath)
     {
         var hashes = new Dictionary<string, int>();
@@ -150,7 +153,7 @@ public class OsuDbReader : BinaryReader
         r.ReadString(true); //Difficulty
         r.ReadString(true);
 
-        dbMapEntryBase.BeatmapChecksum = r.ReadString();
+        dbMapEntryBase.Hash = r.ReadString();
 
         r.ReadString(true); //BeatmapFileName
 

--- a/OsuPlayer.IO/DbReader/RealmReader.cs
+++ b/OsuPlayer.IO/DbReader/RealmReader.cs
@@ -10,8 +10,8 @@ namespace OsuPlayer.IO.DbReader;
 /// </summary>
 public class RealmReader
 {
-    private readonly Realm _realm;
     private readonly IEnumerable<BeatmapInfo> _beatmapInfos;
+    private readonly Realm _realm;
 
     public RealmReader(Config? config = null)
     {
@@ -36,10 +36,10 @@ public class RealmReader
     }
 
     /// <summary>
-    /// Reads the client.realm file from the <paramref name="path"/>
+    /// Reads the client.realm file from the <paramref name="path" />
     /// </summary>
     /// <param name="path">the path where the client.realm is located</param>
-    /// <returns>an <see cref="IList{T}"/> of <see cref="IMapEntryBase"/> read from the client.realm</returns>
+    /// <returns>an <see cref="IList{T}" /> of <see cref="IMapEntryBase" /> read from the client.realm</returns>
     public static async Task<List<IMapEntryBase>?> Read(string path)
     {
         var realmLoc = Path.Combine(path, "client.realm");
@@ -56,17 +56,15 @@ public class RealmReader
         var beatmaps = realm.DynamicApi.All("BeatmapSet").ToList().OfType<BeatmapSetInfo>();
 
         foreach (var beatmap in beatmaps)
-        {
             minBeatMaps.Add(new RealmMapEntryBase
             {
-                Artist = beatmap.Metadata.Artist,
-                BeatmapChecksum = beatmap.Hash,
+                Artist = string.Intern(beatmap.Metadata.Artist),
+                Hash = beatmap.Beatmaps.First().MD5Hash,
                 BeatmapSetId = beatmap.OnlineID,
                 Title = beatmap.Metadata.Title,
                 TotalTime = (int) beatmap.MaxLength,
                 Id = beatmap.ID
             });
-        }
 
         realm.Dispose();
 
@@ -76,8 +74,14 @@ public class RealmReader
     /// <summary>
     /// Queries all beatmaps in the realm
     /// </summary>
-    /// <param name="query">a <see cref="Func{T, TResult}"/> where the query input is a <see cref="BeatmapInfo"/> and the query result is a <see cref="bool"/></param>
-    /// <returns>the first <see cref="BeatmapInfo"/> where the <paramref name="query"/> returns true, or null if no map was found</returns>
+    /// <param name="query">
+    /// a <see cref="Func{T, TResult}" /> where the query input is a <see cref="BeatmapInfo" /> and the
+    /// query result is a <see cref="bool" />
+    /// </param>
+    /// <returns>
+    /// the first <see cref="BeatmapInfo" /> where the <paramref name="query" /> returns true, or null if no map was
+    /// found
+    /// </returns>
     public BeatmapInfo? QueryBeatmap(Func<BeatmapInfo, bool> query)
     {
         return _beatmapInfos.FirstOrDefault(query);

--- a/OsuPlayer.IO/SongImporter.cs
+++ b/OsuPlayer.IO/SongImporter.cs
@@ -4,28 +4,29 @@ using OsuPlayer.IO.DbReader.DataModels;
 namespace OsuPlayer.IO;
 
 /// <summary>
-/// Wrapper class for the <see cref="OsuDbReader"/> and <see cref="RealmReader"/>
+/// Wrapper class for the <see cref="OsuDbReader" /> and <see cref="RealmReader" />
 /// </summary>
 public sealed class SongImporter
 {
     /// <summary>
-    /// Imports the songs from the osu!db or client.realm depending on the file present in the <paramref name="path"/> directory
+    /// Imports the songs from the osu!db or client.realm depending on the file present in the <paramref name="path" />
+    /// directory
     /// </summary>
     /// <param name="path">the path to the osu!(lazer) root folder</param>
-    /// <returns>an <see cref="ICollection{T}"/> of <see cref="IMapEntryBase"/> containing the imported songs</returns>
+    /// <returns>an <see cref="ICollection{T}" /> of <see cref="IMapEntryBase" /> containing the imported songs</returns>
     public static async Task<ICollection<IMapEntryBase>?> ImportSongsAsync(string path)
     {
-        if (string.IsNullOrEmpty(path)) 
+        if (string.IsNullOrEmpty(path))
             return null;
 
         IMapEntryBase[] maps = null;
 
         if (File.Exists(Path.Combine(path, "osu!.db")))
-            maps = (await OsuDbReader.Read(path))?.DistinctBy(x => x.BeatmapChecksum).OrderBy(x => x.BeatmapSetId)
+            maps = (await OsuDbReader.Read(path))?.DistinctBy(x => x.Hash).OrderBy(x => x.BeatmapSetId)
                 //.DistinctBy(x => x.Title)
                 .Where(x => !string.IsNullOrEmpty(x.Title)).ToArray();
         else if (File.Exists(Path.Combine(path, "client.realm")))
-            maps = (await RealmReader.Read(path))?.DistinctBy(x => x.BeatmapChecksum).OrderBy(x => x.BeatmapSetId)
+            maps = (await RealmReader.Read(path))?.DistinctBy(x => x.Hash).OrderBy(x => x.BeatmapSetId)
                 //.DistinctBy(x => x.Title)
                 .Where(x => !string.IsNullOrEmpty(x.Title)).ToArray();
 

--- a/OsuPlayer.IO/Storage/Config/ConfigContainer.cs
+++ b/OsuPlayer.IO/Storage/Config/ConfigContainer.cs
@@ -14,6 +14,6 @@ public class ConfigContainer : IStorableContainer
     public WindowTransparencyLevel TransparencyLevelHint { get; set; } = WindowTransparencyLevel.AcrylicBlur;
     public StartupSong StartupSong { get; set; } = StartupSong.FirstSong;
     public SortingMode SortingMode { get; set; } = SortingMode.Title;
-    public LastPlayedSongModel? LastPlayedSong { get; set; }
+    public string? LastPlayedSong { get; set; }
     public bool IgnoreSongsWithSameNameCheckBox { get; set; }
 }

--- a/OsuPlayer.IO/Storage/Equalizer/EqStorage.cs
+++ b/OsuPlayer.IO/Storage/Equalizer/EqStorage.cs
@@ -7,11 +7,6 @@ public class EqStorage : IStorable<EqContainer>
 {
     private readonly JsonSerializerSettings _serializerSettings = new()
     {
-        Error =  delegate(object? sender, ErrorEventArgs args)
-        {
-            if ((string) args.ErrorContext.Member == "LastPlayedSong")
-                args.ErrorContext.Handled = true;
-        },
         Formatting = Formatting.Indented
     };
 

--- a/OsuPlayer.IO/Storage/Playlists/PlaylistManager.cs
+++ b/OsuPlayer.IO/Storage/Playlists/PlaylistManager.cs
@@ -4,7 +4,8 @@ using OsuPlayer.IO.DbReader.DataModels;
 namespace OsuPlayer.IO.Storage.Playlists;
 
 /// <summary>
-/// A wrapper for the <see cref="PlaylistStorage"/>, containing static methods for creating, deleting and modifying playlists
+/// A wrapper for the <see cref="PlaylistStorage" />, containing static methods for creating, deleting and modifying
+/// playlists
 /// </summary>
 public class PlaylistManager
 {
@@ -47,7 +48,7 @@ public class PlaylistManager
     /// <summary>
     /// Gets all stored playlists
     /// </summary>
-    /// <returns>an <see cref="IList{T}"/> containing all playlists</returns>
+    /// <returns>an <see cref="IList{T}" /> containing all playlists</returns>
     public static IList<Playlist> GetAllPlaylists()
     {
         using (var storage = new PlaylistStorage())
@@ -61,7 +62,7 @@ public class PlaylistManager
     /// <summary>
     /// Gets all stored playlists asynchronously
     /// </summary>
-    /// <returns>an <see cref="IList{T}"/> containing all playlists</returns>
+    /// <returns>an <see cref="IList{T}" /> containing all playlists</returns>
     public static async Task<IList<Playlist>> GetAllPlaylistsAsync()
     {
         await using (var storage = new PlaylistStorage())
@@ -128,7 +129,7 @@ public class PlaylistManager
     }
 
     /// <summary>
-    /// Renames a playlist. Gets the stored playlist by its <see cref="Guid"/> and changes the the name of it
+    /// Renames a playlist. Gets the stored playlist by its <see cref="Guid" /> and changes the the name of it
     /// </summary>
     /// <param name="playlist">The playlist with the new name</param>
     public static async Task RenamePlaylist(Playlist playlist)
@@ -184,7 +185,7 @@ public class PlaylistManager
     /// <param name="mapEntry">The song to toggle</param>
     public static async Task ToggleSongOfCurrentPlaylist(IMapEntryBase mapEntry)
     {
-        if (CurrentPlaylist.Songs.Contains(mapEntry.BeatmapSetId))
+        if (CurrentPlaylist.Songs.Contains(mapEntry.Hash))
             await RemoveSongToCurrentPlaylist(mapEntry);
         else
             await AddSongToCurrentPlaylistAsync(mapEntry);
@@ -196,7 +197,7 @@ public class PlaylistManager
     /// <param name="mapEntry">The song to add</param>
     public static async Task AddSongToCurrentPlaylistAsync(IMapEntryBase mapEntry)
     {
-        CurrentPlaylist.Songs.Add(mapEntry.BeatmapSetId);
+        CurrentPlaylist.Songs.Add(mapEntry.Hash);
 
         await ReplacePlaylistAsync(CurrentPlaylist);
     }
@@ -207,7 +208,7 @@ public class PlaylistManager
     /// <param name="mapEntry">The song to remove</param>
     public static async Task RemoveSongToCurrentPlaylist(IMapEntryBase mapEntry)
     {
-        CurrentPlaylist.Songs.Remove(mapEntry.BeatmapSetId);
+        CurrentPlaylist.Songs.Remove(mapEntry.Hash);
 
         await ReplacePlaylistAsync(CurrentPlaylist);
     }
@@ -233,17 +234,17 @@ public class PlaylistManager
     /// Adds a song to a playlist and creates it if it doesn't exist already
     /// </summary>
     /// <param name="playlistName">the name of the playlist to add the song to</param>
-    /// <param name="setId">the beatmap set id of the song</param>
-    public static async Task AddSongToPlaylistAsync(string playlistName, int setId)
+    /// <param name="hash">the beatmap set id of the song</param>
+    public static async Task AddSongToPlaylistAsync(string playlistName, string hash)
     {
-        if (setId < 0) return;
+        if (string.IsNullOrWhiteSpace(hash)) return;
 
         Playlist playlist;
 
         if ((playlist = (await GetAllPlaylistsAsync()).FirstOrDefault(x => x.Name == playlistName)) != default)
         {
-            if (!playlist.Songs.Contains(setId))
-                playlist.Songs.Add(setId);
+            if (!playlist.Songs.Contains(hash))
+                playlist.Songs.Add(hash);
 
             await ReplacePlaylistAsync(playlist);
             return;
@@ -253,7 +254,7 @@ public class PlaylistManager
         {
             Name = playlistName
         };
-        playlist.Songs.Add(setId);
+        playlist.Songs.Add(hash);
 
         await AddPlaylistAsync(playlist);
     }

--- a/OsuPlayer/Modules/Audio/Player.cs
+++ b/OsuPlayer/Modules/Audio/Player.cs
@@ -91,7 +91,7 @@ public class Player
 
             using var config = new Config();
 
-            config.Container.LastPlayedSong = new LastPlayedSongModel(value!.BeatmapSetId, value.Title, value.Artist);
+            config.Container.LastPlayedSong = value?.Hash;
 
             // _mainWindow.ViewModel!.PlayerControl.CurrentSongImage = Task.Run(value!.FindBackground).Result;
         }
@@ -220,13 +220,13 @@ public class Player
             return;
         }
 
-        if (config.LastPlayedSong.SetId != -1)
+        if (!string.IsNullOrWhiteSpace(config.LastPlayedSong))
         {
-            await PlayAsync(GetMapEntryFromSetId(config.LastPlayedSong.SetId));
+            await PlayAsync(GetMapEntryFromHash(config.LastPlayedSong));
             return;
         }
 
-        await PlayAsync(SongSourceList?.FirstOrDefault(x => x.Title == config.LastPlayedSong.Title && x.Artist == config.LastPlayedSong.Artist));
+        await PlayAsync(SongSourceList?[0]);
     }
 
     /// <summary>

--- a/OsuPlayer/Modules/Audio/Player.cs
+++ b/OsuPlayer/Modules/Audio/Player.cs
@@ -87,7 +87,7 @@ public class Player
         {
             CurrentSongBinding.Value = value;
 
-            CurrentIndex = SongSourceList!.FindIndex(x => x.BeatmapChecksum == value!.BeatmapChecksum);
+            CurrentIndex = SongSourceList!.FindIndex(x => x.Hash == value!.Hash);
 
             using var config = new Config();
 
@@ -189,13 +189,13 @@ public class Player
             foreach (var hash in collection.BeatmapHashes)
                 if (SongSourceList?[0] is RealmMapEntryBase)
                 {
-                    var setId = realmReader?.QueryBeatmap(x => x.MD5Hash == hash)?.BeatmapSet?.OnlineID ?? -1;
-                    await PlaylistManager.AddSongToPlaylistAsync(collection.Name, setId);
+                    var md5Hash = realmReader?.QueryBeatmap(x => x.MD5Hash == hash)?.BeatmapSet?.Beatmaps.First().MD5Hash ?? string.Empty;
+                    await PlaylistManager.AddSongToPlaylistAsync(collection.Name, md5Hash);
                 }
                 else if (SongSourceList?[0] is DbMapEntryBase)
                 {
                     var setId = beatmapHashes?.GetValueOrDefault(hash) ?? -1;
-                    await PlaylistManager.AddSongToPlaylistAsync(collection.Name, setId);
+                    await PlaylistManager.AddSongToPlaylistAsync(collection.Name, SongSourceList.FirstOrDefault(x => x.BeatmapSetId == setId)?.Hash ?? string.Empty);
                 }
 
             Dispatcher.UIThread.Post(() => MessageBox.Show(Locator.Current.GetService<MainWindow>(), "Import successful. Have fun!", "Import complete!"));
@@ -292,7 +292,7 @@ public class Player
 
         if (CurrentSongBinding.Value != null && Repeat != RepeatMode.SingleSong
                                              && (await new Config().ReadAsync()).IgnoreSongsWithSameNameCheckBox
-                                             && CurrentSongBinding.Value.BeatmapChecksum == song.BeatmapChecksum)
+                                             && CurrentSongBinding.Value.Hash == song.Hash)
             if ((await EnqueueSongFromDirectionAsync(playDirection)).IsFaulted)
                 await TryEnqueueSongAsync(SongSourceList![^1]);
 
@@ -313,7 +313,7 @@ public class Player
             {
                 for (var i = CurrentIndex - 1; i < SongSourceList?.Count; i--)
                 {
-                    if (SongSourceList[i].BeatmapChecksum == CurrentSongBinding.Value!.BeatmapChecksum) continue;
+                    if (SongSourceList[i].Hash == CurrentSongBinding.Value!.Hash) continue;
 
                     return await TryEnqueueSongAsync(SongSourceList[i]);
                 }
@@ -324,7 +324,7 @@ public class Player
             {
                 for (var i = CurrentIndex + 1; i < SongSourceList?.Count; i++)
                 {
-                    if (SongSourceList[i].BeatmapChecksum == CurrentSongBinding.Value!.BeatmapChecksum) continue;
+                    if (SongSourceList[i].Hash == CurrentSongBinding.Value!.Hash) continue;
 
                     return await TryEnqueueSongAsync(SongSourceList[i]);
                 }
@@ -416,7 +416,7 @@ public class Player
         var time = (double) _currentSongTimer.ElapsedMilliseconds / 1000;
 
         var response = await ApiAsync.UpdateXpFromCurrentUserAsync(
-            CurrentSongBinding.Value?.BeatmapChecksum ?? string.Empty,
+            CurrentSongBinding.Value?.Hash ?? string.Empty,
             time,
             _bassEngine.ChannelLengthB.Value);
 
@@ -552,12 +552,12 @@ public class Player
                 return;
             }
 
-            var currentPlaylistIndex = ActivePlaylist.Songs.IndexOf(CurrentSong!.BeatmapSetId);
+            var currentPlaylistIndex = ActivePlaylist.Songs.IndexOf(CurrentSong!.Hash);
 
             if (currentPlaylistIndex == ActivePlaylist.Songs.Count - 1)
-                await PlayAsync(GetMapEntryFromSetId(ActivePlaylist.Songs[0]));
+                await PlayAsync(GetMapEntryFromHash(ActivePlaylist.Songs[0]));
             else
-                await PlayAsync(GetMapEntryFromSetId(ActivePlaylist.Songs[currentPlaylistIndex + 1]));
+                await PlayAsync(GetMapEntryFromHash(ActivePlaylist.Songs[currentPlaylistIndex + 1]));
 
             return;
         }
@@ -612,12 +612,12 @@ public class Player
                 return;
             }
 
-            var currentPlaylistIndex = ActivePlaylist.Songs.IndexOf(CurrentSong!.BeatmapSetId);
+            var currentPlaylistIndex = ActivePlaylist.Songs.IndexOf(CurrentSong!.Hash);
 
             if (currentPlaylistIndex <= 0)
-                await PlayAsync(GetMapEntryFromSetId(ActivePlaylist.Songs[^1]));
+                await PlayAsync(GetMapEntryFromHash(ActivePlaylist.Songs[^1]));
             else
-                await PlayAsync(GetMapEntryFromSetId(ActivePlaylist.Songs[currentPlaylistIndex - 1]));
+                await PlayAsync(GetMapEntryFromHash(ActivePlaylist.Songs[currentPlaylistIndex - 1]));
 
             return;
         }
@@ -638,6 +638,16 @@ public class Player
     }
 
     /// <summary>
+    /// Gets the map entry from the beatmap hash
+    /// </summary>
+    /// <param name="hash">the beatmap hash to get the map from</param>
+    /// <returns>an <see cref="IMapEntryBase" /> of the found map or null if it doesn't exist</returns>
+    private IMapEntryBase? GetMapEntryFromHash(string hash)
+    {
+        return SongSourceList!.FirstOrDefault(x => x.Hash == hash);
+    }
+
+    /// <summary>
     /// Gets all Songs from a specific beatmapset ID
     /// </summary>
     /// <param name="setId">The beatmapset ID</param>
@@ -645,6 +655,16 @@ public class Player
     public List<IMapEntryBase> GetMapEntriesFromSetId(ICollection<int> setId)
     {
         return SongSourceList!.Where(x => setId.Contains(x.BeatmapSetId)).ToList();
+    }
+
+    /// <summary>
+    /// Gets all Songs from a specific beatmap hash
+    /// </summary>
+    /// <param name="hash">The beatmap hash</param>
+    /// <returns>A list of <see cref="IMapEntryBase" /></returns>
+    public List<IMapEntryBase> GetMapEntriesFromHash(ICollection<string> hash)
+    {
+        return SongSourceList!.Where(x => hash.Contains(x.Hash)).ToList();
     }
 
     /// <summary>
@@ -712,7 +732,7 @@ public class Player
         var shuffleIndex = (int) _shuffleHistory[_shuffleHistoryIndex];
 
         return Task.FromResult(Repeat == RepeatMode.Playlist
-            ? GetMapEntryFromSetId(ActivePlaylist!.Songs[shuffleIndex])
+            ? GetMapEntryFromHash(ActivePlaylist!.Songs[shuffleIndex])
             : SongSourceList![shuffleIndex]);
     }
 
@@ -726,7 +746,7 @@ public class Player
         if (_shuffleHistory[_shuffleHistoryIndex + 1] == null)
         {
             _shuffleHistory[_shuffleHistoryIndex] = Repeat == RepeatMode.Playlist
-                ? ActivePlaylist?.Songs.IndexOf(CurrentSong!.BeatmapSetId)
+                ? ActivePlaylist?.Songs.IndexOf(CurrentSong!.Hash)
                 : CurrentIndex;
             _shuffleHistory[++_shuffleHistoryIndex] = GenerateShuffledIndex();
         }
@@ -754,7 +774,7 @@ public class Player
         if (_shuffleHistory[_shuffleHistoryIndex - 1] == null)
         {
             _shuffleHistory[_shuffleHistoryIndex] = Repeat == RepeatMode.Playlist
-                ? ActivePlaylist?.Songs.IndexOf(CurrentSong!.BeatmapSetId)
+                ? ActivePlaylist?.Songs.IndexOf(CurrentSong!.Hash)
                 : CurrentIndex;
             _shuffleHistory[--_shuffleHistoryIndex] = GenerateShuffledIndex();
         }
@@ -785,7 +805,7 @@ public class Player
             : SongSourceList!.Count);
 
         while (shuffleIndex == (Repeat == RepeatMode.Playlist
-                   ? ActivePlaylist?.Songs.IndexOf(CurrentSong!.BeatmapSetId)
+                   ? ActivePlaylist?.Songs.IndexOf(CurrentSong!.Hash)
                    : CurrentIndex)) // || OsuPlayer.Blacklist.IsSongInBlacklist(Songs[shuffleIndex]))
             shuffleIndex = rdm.Next(0, Repeat == RepeatMode.Playlist
                 ? ActivePlaylist!.Songs.Count

--- a/OsuPlayer/ValueConverters/PlaylistValueConverter.cs
+++ b/OsuPlayer/ValueConverters/PlaylistValueConverter.cs
@@ -17,7 +17,7 @@ public class PlaylistValueConverter : IValueConverter
     {
         if (value == default) return default;
 
-        return Locator.Current.GetService<Player>().GetMapEntriesFromSetId((ICollection<int>) value);
+        return Locator.Current.GetService<Player>().GetMapEntriesFromHash((ICollection<string>) value);
     }
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/OsuPlayer/Views/PlayerControlViewModel.cs
+++ b/OsuPlayer/Views/PlayerControlViewModel.cs
@@ -31,21 +31,9 @@ public class PlayerControlViewModel : BaseViewModel
     private string _currentSongLength = "00:00";
 
     private string _currentSongTime = "00:00";
-
-    private double _playbackSpeed;
     private bool _isCurrentSongOnBlacklist;
 
-    public bool IsCurrentSongInPlaylist => _currentSong.Value != null
-                                           && PlaylistManager.CurrentPlaylist != null
-                                           && PlaylistManager.CurrentPlaylist.Songs.Contains(_currentSong.Value.BeatmapSetId);
-
-    public bool IsAPlaylistSelected => PlaylistManager.CurrentPlaylist != default;
-
-    public bool IsCurrentSongOnBlacklist
-    {
-        get => _isCurrentSongOnBlacklist;
-        set => this.RaiseAndSetIfChanged(ref _isCurrentSongOnBlacklist, value);
-    }
+    private double _playbackSpeed;
 
     public PlayerControlViewModel(Player player, BassEngine bassEngine)
     {
@@ -86,9 +74,21 @@ public class PlayerControlViewModel : BaseViewModel
             this.RaisePropertyChanged(nameof(IsAPlaylistSelected));
             this.RaisePropertyChanged(nameof(IsCurrentSongInPlaylist));
         }, true);
-        
+
         Activator = new ViewModelActivator();
         this.WhenActivated(disposables => { Disposable.Create(() => { }).DisposeWith(disposables); });
+    }
+
+    public bool IsCurrentSongInPlaylist => _currentSong.Value != null
+                                           && PlaylistManager.CurrentPlaylist != null
+                                           && PlaylistManager.CurrentPlaylist.Songs.Contains(_currentSong.Value.Hash);
+
+    public bool IsAPlaylistSelected => PlaylistManager.CurrentPlaylist != default;
+
+    public bool IsCurrentSongOnBlacklist
+    {
+        get => _isCurrentSongOnBlacklist;
+        set => this.RaiseAndSetIfChanged(ref _isCurrentSongOnBlacklist, value);
     }
 
     public double Volume

--- a/OsuPlayer/Views/PlaylistEditorView.axaml.cs
+++ b/OsuPlayer/Views/PlaylistEditorView.axaml.cs
@@ -50,10 +50,10 @@ public partial class PlaylistEditorView : ReactivePlayerControl<PlaylistEditorVi
 
         foreach (var song in ViewModel.SelectedSongListItems)
         {
-            if (playlist.Contains(song.BeatmapSetId))
+            if (playlist.Contains(song.Hash))
                 continue;
 
-            playlist.Add(song.BeatmapSetId);
+            playlist.Add(song.Hash);
         }
 
         ViewModel.SelectedSongListItems = new List<IMapEntryBase>();
@@ -79,10 +79,10 @@ public partial class PlaylistEditorView : ReactivePlayerControl<PlaylistEditorVi
 
         foreach (var song in ViewModel.SelectedPlaylistItems)
         {
-            if (!playlist.Contains(song.BeatmapSetId))
+            if (!playlist.Contains(song.Hash))
                 continue;
 
-            playlist.Remove(song.BeatmapSetId);
+            playlist.Remove(song.Hash);
         }
 
         ViewModel.SelectedPlaylistItems = new List<IMapEntryBase>();


### PR DESCRIPTION
fixes #63. This was caused by multiple songs having -1 as the set id (all not uploaded maps). This changes the realm importer to use the old md5 hash and changes the data structures to the beatmap hash.