### PR TITLE
Ability to change the release channel

### DIFF
--- a/OsuPlayer.IO/OsuPlayer.IO.csproj
+++ b/OsuPlayer.IO/OsuPlayer.IO.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
         <ProjectReference Include="..\OsuPlayer.Data\OsuPlayer.Data.csproj" />
         <ProjectReference Include="..\OsuPlayer.Extensions\OsuPlayer.Extensions.csproj" />
+        <ProjectReference Include="..\OsuPlayer.Network\OsuPlayer.Network.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OsuPlayer.IO/Storage/Config/ConfigContainer.cs
+++ b/OsuPlayer.IO/Storage/Config/ConfigContainer.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia.Controls;
 using OsuPlayer.Data.OsuPlayer.Enums;
+using OsuPlayer.Network;
 
 namespace OsuPlayer.IO.Storage.Config;
 
@@ -17,6 +18,7 @@ public class ConfigContainer : IStorableContainer
     public bool IgnoreSongsWithSameNameCheckBox { get; set; }
     public bool BlacklistSkip { get; set; }
     public string? Username { get; set; }
+    public ReleaseChannels ReleaseChannel { get; set; } = 0;
 
     public IStorableContainer Init()
     {

--- a/OsuPlayer.Network/GitHubUpdater.cs
+++ b/OsuPlayer.Network/GitHubUpdater.cs
@@ -13,14 +13,14 @@ public static class GitHubUpdater
     /// <summary>
     /// Checks if the current version is older and needs to be updated
     /// </summary>
-    /// <param name="includePreReleases">If pre-releases should be included</param>
-    public static async Task<(bool, string?, string?)> CheckForUpdates(bool includePreReleases = false)
+    /// <param name="releaseChannel">The release channel to be used</param>
+    public static async Task<(bool, string?, string?)> CheckForUpdates(ReleaseChannels releaseChannel = ReleaseChannels.Stable)
     {
         var curVersion = Assembly.GetEntryAssembly()!.GetName().Version;
 
         var currentVersion = $"{curVersion!.Major}.{curVersion.Minor}.{curVersion.Build}";
 
-        var release = await GetLatestRelease(includePreReleases);
+        var release = await GetLatestRelease(releaseChannel);
 
         if (release == default) return (false, null, null);
 
@@ -32,20 +32,22 @@ public static class GitHubUpdater
     /// <summary>
     /// Gets the latest release from GitHub
     /// </summary>
-    /// <param name="includPreReleases">If pre-releases should be included as well</param>
+    /// <param name="releaseChannel">The release channel to be used</param>
     /// <returns>a GitHub release</returns>
-    public static async Task<Release?> GetLatestRelease(bool includPreReleases = false)
+    public static async Task<Release?> GetLatestRelease(ReleaseChannels releaseChannel = ReleaseChannels.Stable)
     {
         var github = new GitHubClient(new ProductHeaderValue("osu!player"));
 
         var releases = await github.Repository.Release.GetAll("Founntain", "osuplayer");
 
-        return releases.FirstOrDefault(x => x.Prerelease == includPreReleases);
+        var includePreReleases = releaseChannel == ReleaseChannels.PreReleases;
+        
+        return releases.FirstOrDefault(x => x.Prerelease == includePreReleases);
     }
 
-    public static async Task<string> GetLatestPatchNotes(bool includePreReleases = false)
+    public static async Task<string> GetLatestPatchNotes(ReleaseChannels releaseChannel = ReleaseChannels.Stable)
     {
-        var release = await GetLatestRelease(includePreReleases);
+        var release = await GetLatestRelease(releaseChannel);
 
         if (release == default)
             return "**No patch-notes found**";

--- a/OsuPlayer.Network/ReleaseChannels.cs
+++ b/OsuPlayer.Network/ReleaseChannels.cs
@@ -1,0 +1,7 @@
+﻿namespace OsuPlayer.Network;
+
+public enum ReleaseChannels
+{
+    Stable = 0,
+    PreReleases = 1
+}

--- a/OsuPlayer/Views/PartyView.axaml
+++ b/OsuPlayer/Views/PartyView.axaml
@@ -4,5 +4,9 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="OsuPlayer.Views.PartyView">
-    <TextBlock Text="work in progress..." VerticalAlignment="Center" HorizontalAlignment="Center" />
+    <StackPanel Spacing="5" VerticalAlignment="Center" HorizontalAlignment="Center">
+        <TextBlock Text="sorry, but this is still work in progress" VerticalAlignment="Center" HorizontalAlignment="Center" />
+        <TextBlock Text="we are working hard to implement this feature for you" VerticalAlignment="Center" HorizontalAlignment="Center" />
+        <Button Content="view progress" Click="Button_OnClick" VerticalAlignment="Center" HorizontalAlignment="Center" />
+    </StackPanel>
 </UserControl>

--- a/OsuPlayer/Views/PartyView.axaml.cs
+++ b/OsuPlayer/Views/PartyView.axaml.cs
@@ -1,5 +1,7 @@
 ﻿using Avalonia.Controls;
+using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
+using OsuPlayer.Extensions;
 
 namespace OsuPlayer.Views;
 
@@ -13,5 +15,10 @@ public partial class PartyView : UserControl
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);
+    }
+
+    private void Button_OnClick(object? sender, RoutedEventArgs e)
+    {
+        GeneralExtensions.OpenUrl("https://github.com/Founntain/osuplayer/issues/70");
     }
 }

--- a/OsuPlayer/Views/SettingsView.axaml
+++ b/OsuPlayer/Views/SettingsView.axaml
@@ -57,6 +57,12 @@
                                     HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" />
                         </StackPanel>
 
+                        <StackPanel Spacing="5" Name="UpdateChannel">
+                            <TextBlock Text="Update channel (changing requires restart)"/>
+                            <ComboBox SelectedItem="{Binding SelectedReleaseChannel}" Items="{Binding ReleaseChannels}"
+                                      HorizontalAlignment="Stretch" />
+                        </StackPanel>
+                        
                         <StackPanel Spacing="5" Name="WindowBlurMethod">
                             <TextBlock Text="Window Blur Method" />
                             <ComboBox SelectedItem="{Binding SelectedTransparencyLevel}"

--- a/OsuPlayer/Views/SettingsViewModel.cs
+++ b/OsuPlayer/Views/SettingsViewModel.cs
@@ -23,6 +23,7 @@ public class SettingsViewModel : BaseViewModel
 
     public MainWindow? MainWindow;
     private string _patchnotes;
+    private ReleaseChannels _selectedReleaseChannel;
 
     public string Patchnotes
     {
@@ -36,6 +37,7 @@ public class SettingsViewModel : BaseViewModel
 
         _selectedStartupSong = config.Container.StartupSong;
         _selectedTransparencyLevel = config.Container.TransparencyLevelHint;
+        _selectedReleaseChannel = config.Container.ReleaseChannel;
 
         Player = player;
 
@@ -53,7 +55,7 @@ public class SettingsViewModel : BaseViewModel
     {
         Disposable.Create(() => { }).DisposeWith(disposables);
 
-        var latestPatchNotes = await GitHubUpdater.GetLatestPatchNotes(true);
+        var latestPatchNotes = await GitHubUpdater.GetLatestPatchNotes(_selectedReleaseChannel);
 
         var regex = new Regex(@"( in )([\w\s:\/\.])*[\d]+");
         latestPatchNotes = regex.Replace(latestPatchNotes, "");
@@ -67,6 +69,20 @@ public class SettingsViewModel : BaseViewModel
     {
         get => $"osu! location: {_osuLocation}";
         set => this.RaiseAndSetIfChanged(ref _osuLocation, value);
+    }
+
+    public IEnumerable<ReleaseChannels> ReleaseChannels => Enum.GetValues<ReleaseChannels>();
+
+    public ReleaseChannels SelectedReleaseChannel
+    {
+        get => _selectedReleaseChannel;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _selectedReleaseChannel, value);
+
+            using var config = new Config();
+            config.Container.ReleaseChannel = value;
+        }
     }
 
     public IEnumerable<WindowTransparencyLevel> WindowTransparencyLevels => Enum.GetValues<WindowTransparencyLevel>();


### PR DESCRIPTION
Closes #71 

This gives the user the ability to change the release channel between **Stable** & **Pre-releases**.
Also only patchnotes are shown to the corresponding release channel. If you choose the stable channel, you only get stable patchnotes, if you choose pre-release you will get all patchnotes including stable releases