### PR TITLE
Fix crashing if no playlist is selected on shuffle

### DIFF
--- a/OsuPlayer/Modules/Audio/Player.cs
+++ b/OsuPlayer/Modules/Audio/Player.cs
@@ -463,7 +463,7 @@ public class Player
 
         if (IsShuffle.Value)
         {
-            await TryPlaySongAsync(await DoShuffle(ShuffleDirection.Backwards), PlayDirection.Backwards);
+            await TryPlaySongAsync(DoShuffle(ShuffleDirection.Backwards), PlayDirection.Backwards);
             return;
         }
 
@@ -499,7 +499,7 @@ public class Player
 
         if (IsShuffle.Value)
         {
-            await TryPlaySongAsync(await DoShuffle(ShuffleDirection.Forward));
+            await TryPlaySongAsync(DoShuffle(ShuffleDirection.Forward));
             return;
         }
 
@@ -753,10 +753,10 @@ public class Player
     /// </summary>
     /// <param name="direction">the <see cref="ShuffleDirection" /> to shuffle to</param>
     /// <returns>a random/shuffled <see cref="IMapEntryBase" /></returns>
-    private Task<IMapEntryBase> DoShuffle(ShuffleDirection direction)
+    private IMapEntryBase? DoShuffle(ShuffleDirection direction)
     {
         if (CurrentSong == default || SongSourceList == default)
-            return Task.FromException<IMapEntryBase>(new NullReferenceException());
+            throw new NullReferenceException();
 
         if (Repeat == Data.OsuPlayer.Enums.RepeatMode.Playlist && ActivePlaylist == default)
         {
@@ -806,9 +806,9 @@ public class Player
         // ReSharper disable once PossibleInvalidOperationException
         var shuffleIndex = (int) _shuffleHistory[_shuffleHistoryIndex];
 
-        return Task.FromResult(Repeat == Data.OsuPlayer.Enums.RepeatMode.Playlist && ActivePlaylist != default
+        return Repeat == Data.OsuPlayer.Enums.RepeatMode.Playlist && ActivePlaylist != default
             ? GetMapEntryFromHash(ActivePlaylist!.Songs[shuffleIndex])
-            : SongSourceList![shuffleIndex]);
+            : SongSourceList![shuffleIndex];
     }
 
     /// <summary>

--- a/OsuPlayer/Modules/Audio/Player.cs
+++ b/OsuPlayer/Modules/Audio/Player.cs
@@ -755,8 +755,13 @@ public class Player
     /// <returns>a random/shuffled <see cref="IMapEntryBase" /></returns>
     private Task<IMapEntryBase> DoShuffle(ShuffleDirection direction)
     {
-        if ((Repeat == Data.OsuPlayer.Enums.RepeatMode.Playlist && ActivePlaylist == default) || CurrentSong == default || SongSourceList == default)
+        if (CurrentSong == default || SongSourceList == default)
             return Task.FromException<IMapEntryBase>(new NullReferenceException());
+
+        if (Repeat == Data.OsuPlayer.Enums.RepeatMode.Playlist && ActivePlaylist == default)
+        {
+            ActivePlaylistId = (PlaylistManager.GetAllPlaylists() as List<Playlist>)?.Find(x => x.Name == "Favorites")?.Id;
+        }
 
         switch (direction)
         {
@@ -801,7 +806,7 @@ public class Player
         // ReSharper disable once PossibleInvalidOperationException
         var shuffleIndex = (int) _shuffleHistory[_shuffleHistoryIndex];
 
-        return Task.FromResult(Repeat == Data.OsuPlayer.Enums.RepeatMode.Playlist
+        return Task.FromResult(Repeat == Data.OsuPlayer.Enums.RepeatMode.Playlist && ActivePlaylist != default
             ? GetMapEntryFromHash(ActivePlaylist!.Songs[shuffleIndex])
             : SongSourceList![shuffleIndex]);
     }


### PR DESCRIPTION
This PR will make it so that the "Favorite" playlist will be automatically selected if no playlist is selected by the user before playing a song.