### PR TITLE
Adding Page-Transitions for smoothing

### DIFF
--- a/OsuPlayer/Windows/MainWindow.axaml
+++ b/OsuPlayer/Windows/MainWindow.axaml
@@ -39,7 +39,7 @@
         <ContentControl Name="TopBarPanel" Grid.Row="0" Content="{Binding TopBar}" />
         <TransitioningContentControl Name="MainViewPanel" Grid.Row="1" Content="{Binding MainView}">
             <TransitioningContentControl.PageTransition>
-                <CrossFade Duration="0:00:00.150"></CrossFade>
+                <CrossFade Duration="0:00:00.150" />
             </TransitioningContentControl.PageTransition>
         </TransitioningContentControl>
         <ContentControl Name="PlayerControlPanel" Grid.Row="2" Content="{Binding PlayerControl}" />

--- a/OsuPlayer/Windows/MainWindow.axaml
+++ b/OsuPlayer/Windows/MainWindow.axaml
@@ -37,7 +37,11 @@
         </Panel>
 
         <ContentControl Name="TopBarPanel" Grid.Row="0" Content="{Binding TopBar}" />
-        <ContentControl Name="MainViewPanel" Grid.Row="1" Content="{Binding MainView}" />
+        <TransitioningContentControl Name="MainViewPanel" Grid.Row="1" Content="{Binding MainView}">
+            <TransitioningContentControl.PageTransition>
+                <CrossFade Duration="0:00:00.150"></CrossFade>
+            </TransitioningContentControl.PageTransition>
+        </TransitioningContentControl>
         <ContentControl Name="PlayerControlPanel" Grid.Row="2" Content="{Binding PlayerControl}" />
     </Grid>
 </Window>


### PR DESCRIPTION
Added page Transitions between pages that are show in the main view with an Crossfade animation. The animation takes 1.5 seconds. 1 second felt to fast and everything starting from 2 and higher to long!