### PR TITLE
Fix some non-critical exceptions caused by some refactor changes

### DIFF
--- a/OsuPlayer/Modules/Audio/Engine/BassEngine.cs
+++ b/OsuPlayer/Modules/Audio/Engine/BassEngine.cs
@@ -334,9 +334,12 @@ public sealed class BassEngine : IAudioEngine
         else
         {
             _inChannelTimerUpdate = true;
+
             var bytes = Bass.ChannelGetPosition(_fxStream);
+
             if (bytes >= 0)
                 ChannelPosition.Value = Bass.ChannelBytes2Seconds(_fxStream, bytes);
+
             _inChannelTimerUpdate = false;
         }
     }

--- a/OsuPlayer/Modules/Audio/Engine/BassEngine.cs
+++ b/OsuPlayer/Modules/Audio/Engine/BassEngine.cs
@@ -334,7 +334,9 @@ public sealed class BassEngine : IAudioEngine
         else
         {
             _inChannelTimerUpdate = true;
-            ChannelPosition.Value = Bass.ChannelBytes2Seconds(_fxStream, Bass.ChannelGetPosition(_fxStream));
+            var bytes = Bass.ChannelGetPosition(_fxStream);
+            if (bytes >= 0)
+                ChannelPosition.Value = Bass.ChannelBytes2Seconds(_fxStream, bytes);
             _inChannelTimerUpdate = false;
         }
     }

--- a/OsuPlayer/Modules/Audio/Engine/BassEngine.cs
+++ b/OsuPlayer/Modules/Audio/Engine/BassEngine.cs
@@ -119,8 +119,6 @@ public sealed class BassEngine : IAudioEngine
 
     public void Stop()
     {
-        ChannelPosition.Value = ChannelLength.Value;
-
         CloseFile();
     }
 
@@ -185,6 +183,9 @@ public sealed class BassEngine : IAudioEngine
 
         Bass.ChannelStop(_fxStream);
         Bass.StreamFree(_decodeStreamHandle);
+
+        _fxStream = 0;
+        _decodeStreamHandle = 0;
 
         ChannelPosition.Value = 0;
     }

--- a/OsuPlayer/Modules/Services/ApiStatisticsProvider.cs
+++ b/OsuPlayer/Modules/Services/ApiStatisticsProvider.cs
@@ -36,7 +36,7 @@ public class ApiStatisticsProvider : IStatisticsProvider
 
         GraphValues.Add(new ObservableValue(xpEarned));
 
-        UserDataChanged?.Invoke(this, new PropertyChangedEventArgs("Xp"));
+        await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() => UserDataChanged?.Invoke(this, new PropertyChangedEventArgs("Xp")));
     }
 
     public async Task UpdateSongsPlayed(int beatmapSetId)
@@ -49,6 +49,6 @@ public class ApiStatisticsProvider : IStatisticsProvider
 
         ProfileManager.User = response;
 
-        UserDataChanged?.Invoke(this, new PropertyChangedEventArgs("SongsPlayed"));
+        await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() => UserDataChanged?.Invoke(this, new PropertyChangedEventArgs("SongsPlayed")));
     }
 }


### PR DESCRIPTION
These exceptions didn't cause a crash, but the debugger breaks each time. Exceptions only rise on playing a new song.