### PR TITLE
Implementation of Miniplayer

### DIFF
--- a/.idea/.idea.OsuPlayer/.idea/avalonia.xml
+++ b/.idea/.idea.OsuPlayer/.idea/avalonia.xml
@@ -32,6 +32,7 @@
         <entry key="OsuPlayer/Windows/CreateProfileWindow.axaml" value="OsuPlayer/OsuPlayer.csproj" />
         <entry key="OsuPlayer/Windows/LoginWindow.axaml" value="OsuPlayer/OsuPlayer.csproj" />
         <entry key="OsuPlayer/Windows/MainWindow.axaml" value="OsuPlayer/OsuPlayer.csproj" />
+        <entry key="OsuPlayer/Windows/Miniplayer.axaml" value="OsuPlayer/OsuPlayer.csproj" />
       </map>
     </option>
   </component>

--- a/OsuPlayer/OsuPlayer.csproj
+++ b/OsuPlayer/OsuPlayer.csproj
@@ -110,6 +110,9 @@
         <Compile Update="Views\BlacklistEditorViewModel.cs">
             <DependentUpon>BlacklistEditorView.axaml</DependentUpon>
         </Compile>
+        <Compile Update="Windows\MiniplayerViewModel.cs">
+          <DependentUpon>Miniplayer.axaml</DependentUpon>
+        </Compile>
     </ItemGroup>
     <ItemGroup>
       <UpToDateCheckInput Remove="Resources\profiles\cesan.jpg" />

--- a/OsuPlayer/Views/PlayerControlView.axaml
+++ b/OsuPlayer/Views/PlayerControlView.axaml
@@ -31,7 +31,6 @@
             <SolidColorBrush Color="{DynamicResource AcrylicSecondaryColor}" />
         </Grid.Background>
 
-
         <Grid Grid.Row="0" ColumnDefinitions="60, *, 60">
 
             <TextBlock x:Name="CurrentSongTimeText" Text="{Binding CurrentSongTime}" VerticalAlignment="Center"
@@ -122,6 +121,11 @@
                         Height="19" Width="19" />
                 </Button>
 
+                <Button Name="OpenMiniPlayer" Width="42" Height="42" CornerRadius="50" Click="OpenMiniPlayer_OnClick"
+                        Background="Transparent" ToolTip.Tip="open miniplayer">
+                    <avalonia:MaterialIcon Kind="ImageSizeSelectSmall" Height="32" Width="32" />
+                </Button>
+                
                 <Button Name="Settings" Width="42" Height="42" CornerRadius="50" Click="Settings_OnClick"
                         Background="Transparent">
                     <avalonia:MaterialIcon Kind="Settings" Height="32" Width="32" />

--- a/OsuPlayer/Views/PlayerControlView.axaml.cs
+++ b/OsuPlayer/Views/PlayerControlView.axaml.cs
@@ -9,14 +9,16 @@ using OsuPlayer.Data.OsuPlayer.StorageModels;
 using OsuPlayer.Extensions;
 using OsuPlayer.IO.Storage.Blacklist;
 using OsuPlayer.IO.Storage.Playlists;
+using OsuPlayer.Modules.Audio.Interfaces;
 using OsuPlayer.Windows;
 using ReactiveUI;
+using Splat;
 
 namespace OsuPlayer.Views;
 
 public partial class PlayerControlView : ReactiveControl<PlayerControlViewModel>
 {
-    private MainWindow _mainWindow;
+    public MainWindow _mainWindow;
 
     private Slider ProgressSlider => this.FindControl<Slider>("SongProgressSlider");
     private Button RepeatButton => this.FindControl<Button>("Repeat");
@@ -141,5 +143,17 @@ public partial class PlayerControlView : ReactiveControl<PlayerControlViewModel>
     private void RepeatContextMenu_OnPointerReleased(object? sender, PointerReleasedEventArgs e)
     {
         ViewModel.Player.SelectedPlaylist.Value = (Playlist) (sender as ContextMenu)?.SelectedItem;
+    }
+
+    private void OpenMiniPlayer_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (_mainWindow.Miniplayer != null)
+            return;
+
+        _mainWindow.Miniplayer = new Miniplayer(_mainWindow, ViewModel.Player, Locator.Current.GetRequiredService<IAudioEngine>());
+
+        _mainWindow.Miniplayer.Show();
+
+        _mainWindow.WindowState = WindowState.Minimized;
     }
 }

--- a/OsuPlayer/Windows/MainWindow.axaml
+++ b/OsuPlayer/Windows/MainWindow.axaml
@@ -9,7 +9,7 @@
         WindowStartupLocation="CenterScreen" CanResize="True"
         Foreground="White"
         
-        FontFamily="MuseoModerno"
+        FontFamily="Montserrat"
         FontWeight="{DynamicResource DefaultFontWeight}"
         FontSize="16"
 

--- a/OsuPlayer/Windows/MainWindow.axaml.cs
+++ b/OsuPlayer/Windows/MainWindow.axaml.cs
@@ -6,16 +6,21 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using OsuPlayer.Base.ViewModels;
 using OsuPlayer.Data.OsuPlayer.Enums;
+using OsuPlayer.Extensions;
 using OsuPlayer.IO.Importer;
+using OsuPlayer.Modules.Audio.Interfaces;
 using OsuPlayer.Network;
 using OsuPlayer.Styles;
 using OsuPlayer.Views;
 using ReactiveUI;
+using Splat;
 
 namespace OsuPlayer.Windows;
 
 public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 {
+    public Miniplayer? Miniplayer;
+    
     public MainWindow()
     {
         InitializeComponent();
@@ -51,6 +56,8 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
         Application.Current!.Resources["BiggerFontWeight"] = config.Container.GetBiggerFont().ToFontWeight();
 
         FontFamily = config.Container.Font ?? FontManager.Current.DefaultFontFamilyName;
+
+        var engine = Locator.Current.GetRequiredService<IAudioEngine>();
     }
 
     private void InitializeComponent()

--- a/OsuPlayer/Windows/Miniplayer.axaml
+++ b/OsuPlayer/Windows/Miniplayer.axaml
@@ -1,0 +1,164 @@
+﻿<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
+        xmlns:cv="clr-namespace:OsuPlayer.Extensions.ValueConverters;assembly=OsuPlayer.Extensions"
+        xmlns:views="clr-namespace:OsuPlayer.Windows"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        x:Class="OsuPlayer.Windows.Miniplayer"
+        Title="osu!player miniplayer"
+
+        MinWidth="285"
+        Width="480"
+        MaxWidth="500"
+        MinHeight="175"
+        Height="175"
+        MaxHeight="200"
+
+        WindowStartupLocation="CenterScreen"
+        Foreground="White"
+
+        FontFamily="Montserrat"
+        FontWeight="{DynamicResource DefaultFontWeight}"
+        FontSize="16"
+
+        Background="Transparent"
+        TransparencyLevelHint="None"
+        ExtendClientAreaToDecorationsHint="True"
+        ExtendClientAreaChromeHints="PreferSystemChrome"
+
+        Topmost="True"
+
+        Icon="avares://OsuPlayer/Resources/x96.ico"
+        
+        Closed="Miniplayer_OnClosed">
+
+    <Window.Resources>
+        <cv:PlayPauseConverter x:Key="PlayPauseConverter" />
+        <cv:ShuffleConverter x:Key="ShuffleConverter" />
+        <cv:RepeatConverter x:Key="RepeatConverter" />
+        <cv:VolumeConverter x:Key="VolumeConverter" />
+    </Window.Resources>
+
+    <Design.DataContext>
+        <views:MiniplayerViewModel />
+    </Design.DataContext>
+
+    <Grid RowDefinitions="35, Auto, Auto, *">
+        <Border Grid.Row="0" Grid.RowSpan="4" >
+            <Image Source="{Binding CurrentSongImage}" Stretch="UniformToFill" />    
+        </Border>
+
+        <Border Grid.Row="0" Background="{DynamicResource AcrylicBaseColor}" Grid.RowSpan="4" />
+
+        <Border Grid.Row="0" Background="Transparent" PointerPressed="TopBarGrid_PointerPressed" />
+
+        <StackPanel Grid.Row="1" HorizontalAlignment="Stretch">
+            <TextBlock Margin="10 0" Text="{Binding TitleText}" HorizontalAlignment="Center" FontSize="18"
+                       FontWeight="{DynamicResource BiggerFontWeight}" TextTrimming="CharacterEllipsis" />
+            <TextBlock Margin="10 0" Text="{Binding ArtistText}" FontWeight="{DynamicResource SmallerFontWeight}"
+                       HorizontalAlignment="Center" TextTrimming="CharacterEllipsis" />
+        </StackPanel>
+
+        <Grid Grid.Row="2" ColumnDefinitions="60, *, 60">
+
+            <TextBlock x:Name="CurrentSongTimeText" Text="{Binding CurrentSongTime}" VerticalAlignment="Center"
+                       Margin="8 0" Grid.Column="0" FontSize="12" HorizontalAlignment="Center" />
+
+            <Slider Name="SongProgressSlider" VerticalAlignment="Center"
+                    Value="{Binding SongTime}"
+                    Maximum="{Binding SongLength}"
+                    Margin="4 0 " UseLayoutRounding="False" Grid.Column="1" />
+
+            <TextBlock Name="CurrentSongTimeLeft" Text="{Binding CurrentSongLength}" VerticalAlignment="Center"
+                       Grid.Column="2" Margin="8 0" FontSize="12" HorizontalAlignment="Center" />
+
+        </Grid>
+
+        <Border Background="{DynamicResource AcrylicBaseColor}" Grid.Row="3" />
+
+        <DockPanel Grid.Row="3" VerticalAlignment="Center" HorizontalAlignment="Center">
+            <Panel>
+                <Button Name="PlaybackSpeed" Width="38" Height="38" CornerRadius="50"
+                        Background="Transparent">
+                    <avalonia:MaterialIcon Kind="PlaySpeed" Height="19" Width="19" />
+                    <Button.Flyout>
+                        <Flyout>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Name="PlaybackSpeedFly" Width="38" Height="38" CornerRadius="50"
+                                        Background="Transparent" Click="PlaybackSpeed_OnClick">
+                                    <avalonia:MaterialIcon Kind="PlaySpeed" Height="19" Width="19" />
+                                </Button>
+                                <Slider VerticalAlignment="Center" HorizontalAlignment="Center" Minimum="-0.25"
+                                        Maximum="0.25"
+                                        Value="{Binding PlaybackSpeed}"
+                                        Orientation="Horizontal" Width="100" Margin="6" />
+                            </StackPanel>
+                        </Flyout>
+                    </Button.Flyout>
+                </Button>
+            </Panel>
+
+            <Button Name="Repeat" Width="38" Height="38" CornerRadius="50" Click="SongControl"
+                    Background="Transparent">
+                <Button.ContextMenu>
+                    <ContextMenu IsVisible="{Binding IsRepeating, Converter={StaticResource RepeatConverter}}"
+                                 Items="{Binding Playlists}" PointerReleased="RepeatContextMenu_OnPointerReleased" />
+                </Button.ContextMenu>
+                <Panel>
+                    <avalonia:MaterialIcon Kind="{Binding IsRepeating, Converter={StaticResource RepeatConverter}}"
+                                           Height="19" Width="19" />
+                    <ToolTip IsVisible="{Binding IsRepeating, Converter={StaticResource RepeatConverter}}">
+                        <ToolTip.Tip>
+                            <TextBlock Text="{Binding ActivePlaylist}" />
+                        </ToolTip.Tip>
+                    </ToolTip>
+                </Panel>
+            </Button>
+
+            <Button Name="Previous" Width="38" Height="38" CornerRadius="50" Click="SongControl"
+                    Background="Transparent">
+                <avalonia:MaterialIcon Kind="SkipBackward" Height="19" Width="19" />
+            </Button>
+
+            <Button Name="PlayPause" Width="50" Height="50" CornerRadius="50" Click="SongControl">
+                <avalonia:MaterialIcon Kind="{Binding IsPlaying, Converter={StaticResource PlayPauseConverter}}"
+                                       Height="40" Width="40" />
+            </Button>
+
+            <Button Name="Next" Width="38" Height="38" CornerRadius="50" Click="SongControl"
+                    Background="Transparent">
+                <avalonia:MaterialIcon Kind="SkipForward" Height="19" Width="19" />
+            </Button>
+
+            <Button Name="Shuffle" Width="38" Height="38" CornerRadius="50" Click="SongControl"
+                    Background="Transparent">
+                <avalonia:MaterialIcon Kind="{Binding IsShuffle, Converter={StaticResource ShuffleConverter}}"
+                                       Height="19" Width="19" />
+            </Button>
+
+            <Panel HorizontalAlignment="Right">
+                <Button Name="Volume" Width="38" Height="38" CornerRadius="50" Background="Transparent">
+                    <avalonia:MaterialIcon Kind="{Binding Volume, Converter={StaticResource VolumeConverter}}"
+                                           Height="19" Width="19" />
+                    <Button.Flyout>
+                        <Flyout>
+                            <StackPanel Orientation="Horizontal">
+                                <Button Name="VolumeFly" Width="38" Height="38" CornerRadius="50"
+                                        Background="Transparent" Click="Volume_OnClick">
+                                    <avalonia:MaterialIcon
+                                        Kind="{Binding Volume, Converter={StaticResource VolumeConverter}}"
+                                        Height="19" Width="19" />
+                                </Button>
+                                <Slider VerticalAlignment="Center" HorizontalAlignment="Center"
+                                        Minimum="0" Maximum="100" Value="{Binding Volume}" Orientation="Horizontal"
+                                        Width="100" Margin="6" />
+                            </StackPanel>
+                        </Flyout>
+                    </Button.Flyout>
+                </Button>
+            </Panel>
+        </DockPanel>
+    </Grid>
+</Window>

--- a/OsuPlayer/Windows/Miniplayer.axaml
+++ b/OsuPlayer/Windows/Miniplayer.axaml
@@ -31,7 +31,7 @@
         Topmost="True"
 
         Icon="avares://OsuPlayer/Resources/x96.ico"
-        
+
         Closed="Miniplayer_OnClosed">
 
     <Window.Resources>
@@ -46,8 +46,8 @@
     </Design.DataContext>
 
     <Grid RowDefinitions="35, Auto, Auto, *">
-        <Border Grid.Row="0" Grid.RowSpan="4" >
-            <Image Source="{Binding CurrentSongImage}" Stretch="UniformToFill" />    
+        <Border Grid.Row="0" Grid.RowSpan="4">
+            <Image Source="{Binding CurrentSongImage}" Stretch="UniformToFill" />
         </Border>
 
         <Border Grid.Row="0" Background="{DynamicResource AcrylicBaseColor}" Grid.RowSpan="4" />

--- a/OsuPlayer/Windows/Miniplayer.axaml.cs
+++ b/OsuPlayer/Windows/Miniplayer.axaml.cs
@@ -1,0 +1,108 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Newtonsoft.Json.Linq;
+using OsuPlayer.Base.ViewModels;
+using OsuPlayer.Data.OsuPlayer.Enums;
+using OsuPlayer.Data.OsuPlayer.StorageModels;
+using OsuPlayer.Extensions;
+using OsuPlayer.Modules.Audio.Interfaces;
+using ReactiveUI;
+
+namespace OsuPlayer.Windows;
+
+public partial class Miniplayer : ReactiveWindow<MiniplayerViewModel>
+{
+    private readonly MainWindow _mainWindow;
+    
+    public Miniplayer()
+    {
+        InitializeComponent();
+
+        LoadSettings();
+        
+#if DEBUG
+        this.AttachDevTools();
+#endif
+    }
+    
+    public Miniplayer(MainWindow mainWindow, IPlayer player, IAudioEngine engine)
+    {
+        InitializeComponent();
+
+        this._mainWindow = mainWindow;
+        
+        DataContext = new MiniplayerViewModel(player, engine);
+        
+        LoadSettings();
+        
+#if DEBUG
+        this.AttachDevTools();
+#endif
+    }
+
+    private void LoadSettings()
+    {
+        using var config = new Config();
+
+        Background = new SolidColorBrush(config.Container.BackgroundColor.ToColor());
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+    
+    private void SongControl(object? sender, RoutedEventArgs e)
+    {
+        switch ((sender as Control)?.Name)
+        {
+            case "Repeat":
+                ViewModel.Player.RepeatMode.Value = ViewModel.Player.RepeatMode.Value.Next();
+                break;
+            case "Previous":
+                ViewModel.Player.NextSong(PlayDirection.Backwards);
+                break;
+            case "PlayPause":
+                ViewModel.Player.PlayPause();
+                break;
+            case "Next":
+                ViewModel.Player.NextSong(PlayDirection.Forward);
+                break;
+            case "Shuffle":
+                ViewModel.IsShuffle = !ViewModel.IsShuffle;
+                break;
+        }
+    }
+    
+    private void RepeatContextMenu_OnPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        ViewModel.Player.SelectedPlaylist.Value = (Playlist) (sender as ContextMenu)?.SelectedItem;
+    }
+
+    private void TopBarGrid_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        BeginMoveDrag(e);
+        e.Handled = false;
+    }
+
+    private void Volume_OnClick(object? sender, RoutedEventArgs e)
+    {
+        ViewModel.Player.ToggleMute();
+    }
+
+    private void PlaybackSpeed_OnClick(object? sender, RoutedEventArgs e)
+    {
+        ViewModel!.PlaybackSpeed = 0;
+    }
+
+    private void Miniplayer_OnClosed(object? sender, EventArgs e)
+    {
+        _mainWindow.Miniplayer = null;
+
+        _mainWindow.WindowState = WindowState.Normal;
+    }
+}

--- a/OsuPlayer/Windows/Miniplayer.axaml.cs
+++ b/OsuPlayer/Windows/Miniplayer.axaml.cs
@@ -4,41 +4,39 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
-using Newtonsoft.Json.Linq;
 using OsuPlayer.Base.ViewModels;
 using OsuPlayer.Data.OsuPlayer.Enums;
 using OsuPlayer.Data.OsuPlayer.StorageModels;
 using OsuPlayer.Extensions;
 using OsuPlayer.Modules.Audio.Interfaces;
-using ReactiveUI;
 
 namespace OsuPlayer.Windows;
 
 public partial class Miniplayer : ReactiveWindow<MiniplayerViewModel>
 {
     private readonly MainWindow _mainWindow;
-    
+
     public Miniplayer()
     {
         InitializeComponent();
 
         LoadSettings();
-        
+
 #if DEBUG
         this.AttachDevTools();
 #endif
     }
-    
+
     public Miniplayer(MainWindow mainWindow, IPlayer player, IAudioEngine engine)
     {
         InitializeComponent();
 
-        this._mainWindow = mainWindow;
-        
+        _mainWindow = mainWindow;
+
         DataContext = new MiniplayerViewModel(player, engine);
-        
+
         LoadSettings();
-        
+
 #if DEBUG
         this.AttachDevTools();
 #endif
@@ -55,7 +53,7 @@ public partial class Miniplayer : ReactiveWindow<MiniplayerViewModel>
     {
         AvaloniaXamlLoader.Load(this);
     }
-    
+
     private void SongControl(object? sender, RoutedEventArgs e)
     {
         switch ((sender as Control)?.Name)
@@ -77,7 +75,7 @@ public partial class Miniplayer : ReactiveWindow<MiniplayerViewModel>
                 break;
         }
     }
-    
+
     private void RepeatContextMenu_OnPointerReleased(object? sender, PointerReleasedEventArgs e)
     {
         ViewModel.Player.SelectedPlaylist.Value = (Playlist) (sender as ContextMenu)?.SelectedItem;

--- a/OsuPlayer/Windows/MiniplayerViewModel.cs
+++ b/OsuPlayer/Windows/MiniplayerViewModel.cs
@@ -12,7 +12,7 @@ namespace OsuPlayer.Windows;
 
 public class MiniplayerViewModel : BaseWindowViewModel
 {
-   private readonly Bindable<bool> _isPlaying = new();
+    private readonly Bindable<bool> _isPlaying = new();
     private readonly Bindable<RepeatMode> _isRepeating = new();
     private readonly Bindable<bool> _isShuffle = new();
     private readonly Bindable<double> _songLength = new();

--- a/OsuPlayer/Windows/MiniplayerViewModel.cs
+++ b/OsuPlayer/Windows/MiniplayerViewModel.cs
@@ -1,0 +1,183 @@
+﻿using Avalonia.Media.Imaging;
+using OsuPlayer.Base.ViewModels;
+using OsuPlayer.Data.OsuPlayer.Enums;
+using OsuPlayer.Data.OsuPlayer.StorageModels;
+using OsuPlayer.Extensions;
+using OsuPlayer.IO.Storage.Blacklist;
+using OsuPlayer.IO.Storage.Playlists;
+using OsuPlayer.Modules.Audio.Interfaces;
+using ReactiveUI;
+
+namespace OsuPlayer.Windows;
+
+public class MiniplayerViewModel : BaseWindowViewModel
+{
+   private readonly Bindable<bool> _isPlaying = new();
+    private readonly Bindable<RepeatMode> _isRepeating = new();
+    private readonly Bindable<bool> _isShuffle = new();
+    private readonly Bindable<double> _songLength = new();
+    private readonly Bindable<double> _songTime = new();
+    private readonly Bindable<double> _volume = new();
+    public readonly Bindable<IMapEntry?> CurrentSong = new();
+
+    public readonly IPlayer Player;
+    private Bitmap? _currentSongImage;
+    private string _currentSongLength = "00:00";
+
+    private string _currentSongTime = "00:00";
+
+    private double _playbackSpeed;
+
+    public bool IsCurrentSongInPlaylist => CurrentSong.Value != null
+                                           && Player.SelectedPlaylist.Value != null
+                                           && Player.SelectedPlaylist.Value.Songs.Contains(CurrentSong.Value.Hash);
+
+    public bool IsAPlaylistSelected => Player.SelectedPlaylist.Value != default;
+
+    public bool IsCurrentSongOnBlacklist => new Blacklist().Contains(CurrentSong.Value);
+
+    public double Volume
+    {
+        get => _volume.Value;
+        set
+        {
+            _volume.Value = value;
+            this.RaisePropertyChanged();
+        }
+    }
+
+    public bool IsShuffle
+    {
+        get => _isShuffle.Value;
+        set
+        {
+            _isShuffle.Value = value;
+            this.RaisePropertyChanged();
+        }
+    }
+
+    public double PlaybackSpeed
+    {
+        get => _playbackSpeed;
+        set
+        {
+            Player.SetPlaybackSpeed(value);
+            this.RaiseAndSetIfChanged(ref _playbackSpeed, value);
+            this.RaisePropertyChanged(nameof(CurrentSongLength));
+        }
+    }
+
+    public double SongTime
+    {
+        get
+        {
+            this.RaisePropertyChanged(nameof(CurrentSongTime));
+            return _songTime.Value;
+        }
+        set => _songTime.Value = value;
+    }
+
+    public string CurrentSongTime
+    {
+        get => TimeSpan.FromSeconds(_songTime.Value * (1 - PlaybackSpeed)).FormatTime();
+        set => this.RaiseAndSetIfChanged(ref _currentSongTime, value);
+    }
+
+    public double SongLength
+    {
+        get
+        {
+            this.RaisePropertyChanged(nameof(CurrentSongLength));
+            return _songLength.Value;
+        }
+    }
+
+    public string CurrentSongLength
+    {
+        get => TimeSpan.FromSeconds(_songLength.Value * (1 - PlaybackSpeed)).FormatTime();
+        set => this.RaiseAndSetIfChanged(ref _currentSongLength, value);
+    }
+
+    public bool IsPlaying => _isPlaying.Value;
+
+    public string TitleText => CurrentSong.Value?.Title ?? "No song is playing";
+
+    public RepeatMode IsRepeating
+    {
+        get => _isRepeating.Value;
+        set
+        {
+            _isRepeating.Value = value;
+            this.RaisePropertyChanged();
+        }
+    }
+
+    public string ArtistText => CurrentSong.Value?.Artist ?? "please select from song list";
+
+    public string SongText => $"{ArtistText} - {TitleText}";
+
+    public Bitmap? CurrentSongImage
+    {
+        get => _currentSongImage;
+        set
+        {
+            _currentSongImage?.Dispose();
+            this.RaiseAndSetIfChanged(ref _currentSongImage, value);
+        }
+    }
+
+    public IEnumerable<Playlist>? Playlists => PlaylistManager.GetAllPlaylists()?.Where(x => x.Songs.Count > 0);
+
+    public string ActivePlaylist => $"Active playlist: {Player.SelectedPlaylist.Value?.Name ?? "none"}";
+
+    public MiniplayerViewModel(IPlayer player, IAudioEngine bassEngine)
+    {
+        Player = player;
+
+        _songTime.BindTo(bassEngine.ChannelPosition);
+        _songTime.BindValueChanged(d => this.RaisePropertyChanged(nameof(SongTime)));
+
+        _songLength.BindTo(bassEngine.ChannelLength);
+        _songLength.BindValueChanged(d => this.RaisePropertyChanged(nameof(SongLength)));
+
+        CurrentSong.BindTo(Player.CurrentSong);
+        CurrentSong.BindValueChanged(d =>
+        {
+            this.RaisePropertyChanged(nameof(TitleText));
+            this.RaisePropertyChanged(nameof(ArtistText));
+            this.RaisePropertyChanged(nameof(SongText));
+            this.RaisePropertyChanged(nameof(IsCurrentSongInPlaylist));
+            this.RaisePropertyChanged(nameof(IsCurrentSongOnBlacklist));
+        });
+
+        _volume.BindTo(Player.Volume);
+        _volume.BindValueChanged(d => this.RaisePropertyChanged(nameof(Volume)));
+
+        _isPlaying.BindTo(Player.IsPlaying);
+        _isPlaying.BindValueChanged(d => this.RaisePropertyChanged(nameof(IsPlaying)));
+
+        _isRepeating.BindTo(Player.RepeatMode);
+        _isRepeating.BindValueChanged(d => { this.RaisePropertyChanged(nameof(IsRepeating)); });
+
+        _isShuffle.BindTo(Player.IsShuffle);
+        _isShuffle.BindValueChanged(d => this.RaisePropertyChanged(nameof(IsShuffle)));
+
+        Player.CurrentSongImage.BindValueChanged(d =>
+        {
+            CurrentSongImage?.Dispose();
+            if (!string.IsNullOrEmpty(d.NewValue) && File.Exists(d.NewValue))
+            {
+                CurrentSongImage = new Bitmap(d.NewValue);
+                return;
+            }
+
+            CurrentSongImage = null;
+        }, true);
+
+        Player.SelectedPlaylist.BindValueChanged(_ =>
+        {
+            this.RaisePropertyChanged(nameof(IsAPlaylistSelected));
+            this.RaisePropertyChanged(nameof(IsCurrentSongInPlaylist));
+        }, true);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -134,4 +134,6 @@ Thanks for reading and have fun with the player, cheers.
 ## 🖼️ Screenshots
 
 ![](https://7.founntain.dev/xR5yZCvY.png)
-![](https://7.founntain.dev/JZvjRNY4.png)
+![](https://7.founntain.dev/JZvjRNY4.png)  
+### Miniplayer  
+![](https://7.founntain.dev/ThrcgojY.png)


### PR DESCRIPTION
Implements a miniplayer that is always on top of everything, to give users the ability to control the player with a small and compact design.

The user is able to: Play/Pause, Skip songs, toggle repeat/ shuffle, adjust volume and speed

The miniplayer uses the Background of the current song instead of the background color set in the settings. if no background ist found the player fallbacks to the default color, set in the settings.

Opening the miniplayer minimizes the main window and resets its state when the miniplayer is closed. Also it is only possible to have one active miniplayer open.

The miniplayer can be opened via the button next to the settings button!

![](https://7.founntain.dev/ijmb9WKU.png)