### PR TITLE
Using switches instead of checkboxes

### DIFF
--- a/OsuPlayer/Views/EqualizerView.axaml
+++ b/OsuPlayer/Views/EqualizerView.axaml
@@ -20,9 +20,9 @@
         <Grid Grid.ColumnSpan="2" Margin="10, 10">
             <TextBlock Text="EQ Editor" VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="22" />
             <DockPanel LastChildFill="False">
-                <StackPanel Orientation="Horizontal" Margin="0 0 10 0">
-                    <CheckBox Name="EqEnabled" IsChecked="{Binding IsEqEnabled}" VerticalAlignment="Center" />
+                <StackPanel Orientation="Vertical" Margin="0 0 10 0">
                     <TextBlock Text="Enable equalizer" VerticalAlignment="Center" />
+                    <ToggleSwitch Name="EqEnabled" IsChecked="{Binding IsEqEnabled}" VerticalAlignment="Center" />
                 </StackPanel>
 
                 <Panel Margin="0 0 10 0" VerticalAlignment="Center" DockPanel.Dock="Right"

--- a/OsuPlayer/Views/SettingsView.axaml
+++ b/OsuPlayer/Views/SettingsView.axaml
@@ -89,14 +89,14 @@
                         </StackPanel>
 
                         <StackPanel Spacing="5" Name="BlacklistSkip">
-                            <CheckBox IsChecked="{Binding BlacklistSkip}" Content="Blacklist skipping" />
+                            <ToggleSwitch IsChecked="{Binding BlacklistSkip}" Content="Blacklist skipping" />
                         </StackPanel>
 
                         <StackPanel Spacing="5" Name="PlaylistEnableOnPlay">
                             <ToolTip.Tip>
                                 This will enable the playlist mode when you play a song directly from the playlist viewer.
                             </ToolTip.Tip>
-                            <CheckBox IsChecked="{Binding PlaylistEnableOnPlay}"
+                            <ToggleSwitch IsChecked="{Binding PlaylistEnableOnPlay}"
                                       Content="Enable playlist mode on song play" />
                         </StackPanel>
                     </StackPanel>


### PR DESCRIPTION
As the title says, I replaced the checkboxes to ToggleSwitches inside the Settings and Equalizer view. Looks way better for me and also fits more to modern design

![](https://7.founntain.dev/B4Su9yyD.png)