### PR TITLE
Fix invalid songs in playlist crashing player

### DIFF
--- a/OsuPlayer.IO/Importer/ISongSourceProvider.cs
+++ b/OsuPlayer.IO/Importer/ISongSourceProvider.cs
@@ -23,10 +23,11 @@ public interface ISongSourceProvider
     /// <summary>
     /// Gets the <see cref="IMapEntryBase" />s by a md5 hash enumerable
     /// </summary>
-    /// <param name="hash">The md5 hashes to find the entries for</param>
+    /// <param name="hashes">The md5 hashes to find the entries for</param>
+    /// <param name="invalidHashes">The md5 hashes that could not be mapped to a map entry</param>
     /// <returns>
     /// A <see cref="List{T}" /> of <see cref="IMapEntryBase" />s which contain all found entries. The list will be
     /// empty of none found
     /// </returns>
-    public List<IMapEntryBase> GetMapEntriesFromHash(IEnumerable<string> hash);
+    public List<IMapEntryBase> GetMapEntriesFromHash(ICollection<string> hashes, out ICollection<string> invalidHashes);
 }

--- a/OsuPlayer.Network/Discord/DiscordClient.cs
+++ b/OsuPlayer.Network/Discord/DiscordClient.cs
@@ -33,13 +33,8 @@ public class DiscordClient
     /// Initializes the Discord Client and prepares all events
     /// </summary>
     /// <returns>itself</returns>
-    public DiscordClient? Initialize(bool useDiscord)
+    public DiscordClient? Initialize()
     {
-        if (!useDiscord)
-        {
-            return null;
-        }
-        
         _client.Logger = new ConsoleLogger
         {
             Level = LogLevel.Warning

--- a/OsuPlayer/Modules/Audio/Player.cs
+++ b/OsuPlayer/Modules/Audio/Player.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Avalonia;
@@ -125,7 +125,16 @@ public class Player : IPlayer, IImportNotifications
 
             if (d.NewValue == null) return;
 
-            ActivePlaylistSongs = SongSourceProvider.GetMapEntriesFromHash(d.NewValue.Songs);
+            ActivePlaylistSongs = SongSourceProvider.GetMapEntriesFromHash(d.NewValue.Songs, out var invalidHashes);
+
+            if (invalidHashes.Any())
+            {
+                using var playlists = new PlaylistStorage();
+
+                var playlist = playlists.Container.Playlists?.First(x => x.Id == d.NewValue.Id);
+
+                playlist?.Songs.RemoveWhere(song => invalidHashes.Contains(song));
+            }
 
             if (RepeatMode.Value != Data.OsuPlayer.Enums.RepeatMode.Playlist || CurrentSong.Value == null) return;
 

--- a/OsuPlayer/Modules/Audio/Player.cs
+++ b/OsuPlayer/Modules/Audio/Player.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Avalonia;
@@ -79,8 +79,8 @@ public class Player : IPlayer, IImportNotifications
         _audioEngine.ChannelReachedEnd = () => NextSong(PlayDirection.Forward);
 
         var config = new Config();
-        
-        _discordClient = new DiscordClient().Initialize(config.Container.UseDiscordRpc);
+
+        _discordClient = config.Container.UseDiscordRpc ? new DiscordClient().Initialize() : null;
 
         SongSourceProvider = songSourceProvider;
         _shuffleProvider = shuffleProvider;
@@ -107,7 +107,7 @@ public class Player : IPlayer, IImportNotifications
 
             if (d.NewValue is null) return;
 
-            _discordClient.UpdatePresence(d.NewValue.Title, $"by {d.NewValue.Artist}");
+            _discordClient?.UpdatePresence(d.NewValue.Title, $"by {d.NewValue.Artist}");
         }, true);
 
         RepeatMode.BindValueChanged(d =>

--- a/OsuPlayer/Modules/Services/OsuSongSourceProvider.cs
+++ b/OsuPlayer/Modules/Services/OsuSongSourceProvider.cs
@@ -1,4 +1,5 @@
-﻿using DynamicData;
+﻿using System.Collections;
+using DynamicData;
 using OsuPlayer.IO.Importer;
 
 namespace OsuPlayer.Modules.Services;
@@ -34,9 +35,18 @@ public class OsuSongSourceProvider : ISongSourceProvider
         return SongSourceList!.FirstOrDefault(x => x.Hash == hash);
     }
 
-    public List<IMapEntryBase> GetMapEntriesFromHash(IEnumerable<string> hash)
+    public List<IMapEntryBase> GetMapEntriesFromHash(ICollection<string> hashes, out ICollection<string> invalidHashes)
     {
-        //return SongSourceList!.FindAll(x => hash.Contains(x.Hash));
-        return hash.Select(x => SongSourceList!.FirstOrDefault(map => map.Hash == x)).ToList();
+        var maps = hashes.Select(x => SongSourceList!.FirstOrDefault(map => map.Hash == x)).ToArray();
+
+        invalidHashes = new List<string>();
+
+        for (var i = 0; i < maps.Length; i++)
+        {
+            if (maps[i] == null)
+                invalidHashes.Add(hashes.ElementAt(i));
+        }
+
+        return maps.Where(map => map != null).ToList();
     }
 }

--- a/OsuPlayer/ValueConverters/PlaylistValueConverter.cs
+++ b/OsuPlayer/ValueConverters/PlaylistValueConverter.cs
@@ -16,7 +16,7 @@ public class PlaylistValueConverter : IValueConverter
     {
         if (value == default) return default;
 
-        return Locator.Current.GetRequiredService<ISongSourceProvider>().GetMapEntriesFromHash((ICollection<string>) value);
+        return Locator.Current.GetRequiredService<ISongSourceProvider>().GetMapEntriesFromHash((ICollection<string>) value, out _);
     }
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/OsuPlayer/Views/PlaylistView.axaml.cs
+++ b/OsuPlayer/Views/PlaylistView.axaml.cs
@@ -55,14 +55,12 @@ public partial class PlaylistView : ReactiveControl<PlaylistViewModel>
         await ViewModel.Player.TryPlaySongAsync(song);
     }
 
-    private async void PlayPlaylist_OnClick(object? sender, RoutedEventArgs e)
+    private void PlayPlaylist_OnClick(object? sender, RoutedEventArgs e)
     {
         if (sender is not Control {DataContext: Playlist playlist}) return;
 
-        ViewModel.Player.SelectedPlaylist.Value = playlist;
         ViewModel.Player.RepeatMode.Value = RepeatMode.Playlist;
-
-        await ViewModel.Player.TryPlaySongAsync(ViewModel.Player.SongSourceProvider.GetMapEntryFromHash(playlist.Songs.First()));
+        ViewModel.Player.SelectedPlaylist.Value = playlist;
     }
 
     private void PlaylistItemLoaded(object? sender, VisualTreeAttachmentEventArgs e)

--- a/OsuPlayer/Views/PlaylistViewModel.cs
+++ b/OsuPlayer/Views/PlaylistViewModel.cs
@@ -42,7 +42,7 @@ public class PlaylistViewModel : BaseViewModel
                 _currentBind.Dispose();
 
             if (_selectedPlaylist?.Songs != null)
-                _currentBind = Player.SongSourceProvider.GetMapEntriesFromHash(_selectedPlaylist.Songs).ToSourceList().Connect()
+                _currentBind = Player.SongSourceProvider.GetMapEntriesFromHash(_selectedPlaylist.Songs, out _).ToSourceList().Connect()
                     .Filter(_filter, ListFilterPolicy.ClearAndReplace).ObserveOn(AvaloniaScheduler.Instance)
                     .Bind(out _filteredSongEntries).Subscribe();
 

--- a/OsuPlayer/Views/SettingsViewModel.cs
+++ b/OsuPlayer/Views/SettingsViewModel.cs
@@ -238,8 +238,7 @@ public class SettingsViewModel : BaseViewModel
         get => _useDiscordRpc;
         set
         {
-            _useDiscordRpc = value;
-            this.RaisePropertyChanged();
+            this.RaiseAndSetIfChanged(ref _useDiscordRpc, value);
 
             using var cfg = new Config();
             cfg.Container.UseDiscordRpc = value;


### PR DESCRIPTION
Fixes  #157.

This ignores all invalid songs in the playlist window visually.
If a playlist containing invalid songs gets played the invalid songs are deleted from the playlists file.