### PR TITLE
Fixing crash on login window

### DIFF
--- a/OsuPlayer/Views/HomeView.axaml.cs
+++ b/OsuPlayer/Views/HomeView.axaml.cs
@@ -55,7 +55,7 @@ public partial class HomeView : ReactiveControl<HomeViewModel>
     {
         if (ViewModel == default) return;
 
-        var loginWindow = new LoginWindow();
+        var loginWindow = new LoginWindow(_mainWindow);
 
         await loginWindow.ShowDialog(_mainWindow);
 

--- a/OsuPlayer/Views/HomeView.axaml.cs
+++ b/OsuPlayer/Views/HomeView.axaml.cs
@@ -55,7 +55,7 @@ public partial class HomeView : ReactiveControl<HomeViewModel>
     {
         if (ViewModel == default) return;
 
-        var loginWindow = new LoginWindow(_mainWindow);
+        var loginWindow = new LoginWindow();
 
         await loginWindow.ShowDialog(_mainWindow);
 

--- a/OsuPlayer/Windows/LoginWindow.axaml.cs
+++ b/OsuPlayer/Windows/LoginWindow.axaml.cs
@@ -19,6 +19,13 @@ public partial class LoginWindow : ReactiveWindow<LoginWindowViewModel>
         Init();
     }
 
+    public LoginWindow(MainWindow mainWindow)
+    {
+        Init();
+
+        _mainWindow = mainWindow;
+    }
+    
     public LoginWindow(MainWindow mainWindow, string username)
     {
         Init();

--- a/OsuPlayer/Windows/LoginWindow.axaml.cs
+++ b/OsuPlayer/Windows/LoginWindow.axaml.cs
@@ -12,25 +12,14 @@ namespace OsuPlayer.Windows;
 
 public partial class LoginWindow : ReactiveWindow<LoginWindowViewModel>
 {
-    private readonly MainWindow _mainWindow;
-
     public LoginWindow()
     {
         Init();
     }
 
-    public LoginWindow(MainWindow mainWindow)
+    public LoginWindow(string username)
     {
         Init();
-
-        _mainWindow = mainWindow;
-    }
-    
-    public LoginWindow(MainWindow mainWindow, string username)
-    {
-        Init();
-
-        _mainWindow = mainWindow;
 
         if (ViewModel == default) return;
 
@@ -70,7 +59,7 @@ public partial class LoginWindow : ReactiveWindow<LoginWindowViewModel>
 
         if (user == default)
         {
-            await MessageBox.ShowDialogAsync(_mainWindow, "Login failed, please try again!", "Login failed");
+            await MessageBox.ShowDialogAsync(this, "Login failed, please try again!", "Login failed");
 
             ViewModel.Password = string.Empty;
 
@@ -79,7 +68,7 @@ public partial class LoginWindow : ReactiveWindow<LoginWindowViewModel>
 
         if (user.Name != ViewModel.Username)
         {
-            await MessageBox.ShowDialogAsync(_mainWindow, "Could not retrieve the correct user from the API! Please try again later!", "Login failed");
+            await MessageBox.ShowDialogAsync(this, "Could not retrieve the correct user from the API! Please try again later!", "Login failed");
 
             ViewModel.Password = string.Empty;
 

--- a/OsuPlayer/Windows/MainWindow.axaml.cs
+++ b/OsuPlayer/Windows/MainWindow.axaml.cs
@@ -117,7 +117,7 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 
         if (string.IsNullOrWhiteSpace(username)) return;
 
-        var loginWindow = new LoginWindow(this, username);
+        var loginWindow = new LoginWindow(username);
         await loginWindow.ShowDialog(this);
 
         // We only want to update the user panel, when the home view is already open, to refresh the panel.


### PR DESCRIPTION
Fixes #168 

The crash was caused, because when the player doesn't remember a username the player opens the login window with the default constructor. Which had the side effect, that the MainWindow instance is never passed to the login window. Which results into a crash, when the trying to open a message box async. (Because it needs a Window).

Therefor I removed the MainWindow compeltely from the Login Window. Because it isn't needed for the MessageBox dialog, because the Login Window is obviously it's own window. Idk why we did this back then, but it was really stupid. However it is fixed now and works as intended