### PR TITLE
Fixed Crash when BackgroundFinder couldn't find a part of the path

### DIFF
--- a/OsuPlayer.IO/DbReader/DataModels/DbMapEntry.cs
+++ b/OsuPlayer.IO/DbReader/DataModels/DbMapEntry.cs
@@ -1,4 +1,6 @@
-﻿namespace OsuPlayer.IO.DbReader.DataModels;
+﻿using System.Diagnostics;
+
+namespace OsuPlayer.IO.DbReader.DataModels;
 
 /// <summary>
 /// a full beatmap entry with optionally used data
@@ -21,7 +23,18 @@ internal class DbMapEntry : DbMapEntryBase, IMapEntry
         if (string.IsNullOrEmpty(FolderPath))
             return null;
 
-        var files = Directory.GetFiles(FolderPath, "*.osu");
+        string[] files;
+        
+        try
+        {
+           files = Directory.GetFiles(FolderPath, "*.osu");
+        }
+        catch(Exception ex)
+        {
+            Debug.WriteLine(ex);
+
+            return null;
+        }
 
         if (files.Length == 0)
             return null;


### PR DESCRIPTION
Fixes #186 

This just adds a small safety check if the user has for some reason a weird / broken osu! directory or even PC structure in general. This helps us, because the player doesn't crash anymore if it should load a background with a broken path and instead just doesn't load an image in general.