### PR TITLE
NorthFox Improvements

### DIFF
--- a/OsuPlayer.Network/API/Service/Endpoints/Nortfox.cs
+++ b/OsuPlayer.Network/API/Service/Endpoints/Nortfox.cs
@@ -1,5 +1,8 @@
 ﻿using System.Text;
+using Newtonsoft.Json;
+using OsuPlayer.Api.Data.API;
 using OsuPlayer.Api.Data.API.EntityModels;
+using OsuPlayer.Api.Data.API.RequestModels.User.Responses;
 
 namespace OsuPlayer.Network.API.Service.Endpoints;
 
@@ -7,8 +10,16 @@ namespace OsuPlayer.Network.API.Service.Endpoints;
 /// NorthFox is the wrapper for the OsuPlayer.API and provides access to all public available API Endpoints!
 /// Yes I like foxes :)
 /// </summary>
-public partial class NorthFox
+public class NorthFox : AbstractApiBase
 {
+    public NorthFoxActivityEndpoint Activity { get; set; }
+    public NorthFoxApiStatisticsEndpoint ApiStatistics { get; set; }
+    public NorthFoxBadgeEndpoint Badge { get; set; }
+    public NorthFoxBeatmapEndpoint Beatmap { get; set; }
+    public NorthFoxEventEndpoint Event { get; set; }
+    public NorthFoxUserEndpoint User { get; set; }
+    public NorthFoxUserStatisticsEndpoint UserStatistics { get; set; }
+    
     public async Task<UserModel?> LoginAndSaveAuthToken(string username, string password)
     {
         var response = await Login(username, password);
@@ -30,4 +41,73 @@ public partial class NorthFox
 
         return response?.User;
     }
+
+    #region Authentication
+
+    public async Task<UserTokenResponse?> Login(string username, string password)
+    {
+        if (Constants.OfflineMode)
+            return default;
+
+        try
+        {
+            using var client = new HttpClient();
+
+            var url = new Uri($"{Url}User/login");
+
+            var req = new HttpRequestMessage(HttpMethod.Post, url);
+            req.Headers.Authorization = GetAuthorizationHeader(username, password);
+
+            // CancelCancellationToken();
+
+            var result = await client.SendAsync(req, CancellationTokenSource.Token);
+
+            var response = JsonConvert.DeserializeObject<ApiResponse<UserTokenResponse>>(await result.Content.ReadAsStringAsync());
+
+            return response.Errors?.Any() == true
+                ? default
+                : response.Value;
+        }
+        catch (Exception ex)
+        {
+            ParseWebException(ex);
+
+            return default;
+        }
+    }
+
+    public async Task<UserTokenResponse?> Login(string token)
+    {
+        if (Constants.OfflineMode)
+            return default;
+
+        try
+        {
+            using var client = new HttpClient();
+
+            var url = new Uri($"{Url}User/loginWithToken");
+
+            var req = new HttpRequestMessage(HttpMethod.Post, url);
+
+            req.Headers.Add("session-token", token);
+
+            // CancelCancellationToken();
+
+            var result = await client.SendAsync(req, CancellationTokenSource.Token);
+
+            var response = JsonConvert.DeserializeObject<ApiResponse<UserTokenResponse>>(await result.Content.ReadAsStringAsync());
+
+            return response.Errors?.Any() == true
+                ? default
+                : response.Value;
+        }
+        catch (Exception ex)
+        {
+            ParseWebException(ex);
+
+            return default;
+        }
+    }
+
+    #endregion
 }

--- a/OsuPlayer.Network/API/Service/Endpoints/NorthFox.Activity.cs
+++ b/OsuPlayer.Network/API/Service/Endpoints/NorthFox.Activity.cs
@@ -2,7 +2,7 @@
 
 namespace OsuPlayer.Network.API.Service.Endpoints;
 
-public partial class NorthFox
+public class NorthFoxActivityEndpoint : AbstractApiBase
 {
     #region GET Requests
 

--- a/OsuPlayer.Network/API/Service/Endpoints/NorthFox.ApiStatistics.cs
+++ b/OsuPlayer.Network/API/Service/Endpoints/NorthFox.ApiStatistics.cs
@@ -2,7 +2,7 @@
 
 namespace OsuPlayer.Network.API.Service.Endpoints;
 
-public partial class NorthFox
+public class NorthFoxApiStatisticsEndpoint : AbstractApiBase
 {
     #region GET Requests
 

--- a/OsuPlayer.Network/API/Service/Endpoints/NorthFox.Badge.cs
+++ b/OsuPlayer.Network/API/Service/Endpoints/NorthFox.Badge.cs
@@ -2,7 +2,7 @@
 
 namespace OsuPlayer.Network.API.Service.Endpoints;
 
-public partial class NorthFox
+public class NorthFoxBadgeEndpoint : AbstractApiBase
 {
     #region GET Requests
 

--- a/OsuPlayer.Network/API/Service/Endpoints/NorthFox.Beatmap.cs
+++ b/OsuPlayer.Network/API/Service/Endpoints/NorthFox.Beatmap.cs
@@ -4,7 +4,7 @@ using OsuPlayer.Api.Data.API.RequestModels.Statistics;
 
 namespace OsuPlayer.Network.API.Service.Endpoints;
 
-public partial class NorthFox
+public class NorthFoxBeatmapEndpoint : AbstractApiBase
 {
     #region POST Requests
 

--- a/OsuPlayer.Network/API/Service/Endpoints/NorthFox.Event.cs
+++ b/OsuPlayer.Network/API/Service/Endpoints/NorthFox.Event.cs
@@ -2,7 +2,7 @@
 
 namespace OsuPlayer.Network.API.Service.Endpoints;
 
-public partial class NorthFox
+public class NorthFoxEventEndpoint : AbstractApiBase
 {
     #region GET Requests
 

--- a/OsuPlayer.Network/API/Service/Endpoints/NorthFox.User.cs
+++ b/OsuPlayer.Network/API/Service/Endpoints/NorthFox.User.cs
@@ -7,7 +7,7 @@ using OsuPlayer.Api.Data.API.RequestModels.User.Responses;
 
 namespace OsuPlayer.Network.API.Service.Endpoints;
 
-public partial class NorthFox : AbstractApiBase
+public class NorthFoxUserEndpoint : AbstractApiBase
 {
     #region DELETE Requests
 
@@ -101,71 +101,6 @@ public partial class NorthFox : AbstractApiBase
     public async Task<UserModel?> Register(AddUserModel data)
     {
         return await PostRequestAsync<UserModel>("User", "register", data);
-    }
-
-    public async Task<UserTokenResponse?> Login(string username, string password)
-    {
-        if (Constants.OfflineMode)
-            return default;
-
-        try
-        {
-            using var client = new HttpClient();
-
-            var url = new Uri($"{Url}User/login");
-
-            var req = new HttpRequestMessage(HttpMethod.Post, url);
-            req.Headers.Authorization = GetAuthorizationHeader(username, password);
-
-            // CancelCancellationToken();
-
-            var result = await client.SendAsync(req, CancellationTokenSource.Token);
-
-            var response = JsonConvert.DeserializeObject<ApiResponse<UserTokenResponse>>(await result.Content.ReadAsStringAsync());
-
-            return response.Errors?.Any() == true
-                ? default
-                : response.Value;
-        }
-        catch (Exception ex)
-        {
-            ParseWebException(ex);
-
-            return default;
-        }
-    }
-
-    public async Task<UserTokenResponse?> Login(string token)
-    {
-        if (Constants.OfflineMode)
-            return default;
-
-        try
-        {
-            using var client = new HttpClient();
-
-            var url = new Uri($"{Url}User/loginWithToken");
-
-            var req = new HttpRequestMessage(HttpMethod.Post, url);
-
-            req.Headers.Add("session-token", token);
-
-            // CancelCancellationToken();
-
-            var result = await client.SendAsync(req, CancellationTokenSource.Token);
-
-            var response = JsonConvert.DeserializeObject<ApiResponse<UserTokenResponse>>(await result.Content.ReadAsStringAsync());
-
-            return response.Errors?.Any() == true
-                ? default
-                : response.Value;
-        }
-        catch (Exception ex)
-        {
-            ParseWebException(ex);
-
-            return default;
-        }
     }
 
     public async Task<UserModel?> EditUser(EditUserModel editData)

--- a/OsuPlayer.Network/API/Service/Endpoints/NorthFox.UserStatistics.cs
+++ b/OsuPlayer.Network/API/Service/Endpoints/NorthFox.UserStatistics.cs
@@ -3,7 +3,7 @@ using OsuPlayer.Api.Data.API.RequestModels.Statistics;
 
 namespace OsuPlayer.Network.API.Service.Endpoints;
 
-public partial class NorthFox
+public class NorthFoxUserStatisticsEndpoint : AbstractApiBase
 {
     #region POST Requests
 

--- a/OsuPlayer/Modules/Services/ApiStatisticsProvider.cs
+++ b/OsuPlayer/Modules/Services/ApiStatisticsProvider.cs
@@ -21,7 +21,7 @@ public class ApiStatisticsProvider : IStatisticsProvider
         if (ProfileManager.User == default || ProfileManager.User.UniqueId == Guid.Empty)
             return;
 
-        await Locator.Current.GetService<NorthFox>().SetOnlineStatus(new UserOnlineStatusModel
+        await Locator.Current.GetService<NorthFox>().User.SetOnlineStatus(new UserOnlineStatusModel
         {
             StatusType = statusType,
             Song = song,
@@ -37,7 +37,7 @@ public class ApiStatisticsProvider : IStatisticsProvider
 
         var time = timeListened / 1000;
 
-        var response = await Locator.Current.GetService<NorthFox>().UpdateXp(new UpdateXpModel
+        var response = await Locator.Current.GetService<NorthFox>().User.UpdateXp(new UpdateXpModel
         {
             SongChecksum = hash,
             ChannelLength = channelLength,
@@ -59,7 +59,7 @@ public class ApiStatisticsProvider : IStatisticsProvider
     {
         if (ProfileManager.User == default) return;
 
-        var response = await Locator.Current.GetService<NorthFox>().UpdateSongsPlayed(1, beatmapSetId);
+        var response = await Locator.Current.GetService<NorthFox>().User.UpdateSongsPlayed(1, beatmapSetId);
 
         if (response == default) return;
 

--- a/OsuPlayer/Views/EditUserView.axaml.cs
+++ b/OsuPlayer/Views/EditUserView.axaml.cs
@@ -137,7 +137,7 @@ public partial class EditUserView : ReactiveUserControl<EditUserViewModel>
 
         var api = Locator.Current.GetService<NorthFox>();
 
-        var tempUser = await api.GetUserFromLoginToken();
+        var tempUser = await api.User.GetUserFromLoginToken();
 
         var changedProfilePicture = ViewModel.IsNewProfilePictureSelected;
 
@@ -184,7 +184,7 @@ public partial class EditUserView : ReactiveUserControl<EditUserViewModel>
                 : ViewModel.NewPassword
         };
 
-        var response = await api.EditUser(editUserModel);
+        var response = await api.User.EditUser(editUserModel);
 
         if (response == default)
             return;
@@ -192,7 +192,7 @@ public partial class EditUserView : ReactiveUserControl<EditUserViewModel>
         if (ViewModel == null)
         {
             if (!string.IsNullOrWhiteSpace(editUserModel.User.Name))
-                ProfileManager.User = (await api.GetUserFromLoginToken())?.ConvertObjectToJson<User>();
+                ProfileManager.User = (await api.User.GetUserFromLoginToken())?.ConvertObjectToJson<User>();
 
             if (changedProfilePicture)
                 await MessageBox.ShowDialogAsync(_mainWindow,
@@ -229,7 +229,7 @@ public partial class EditUserView : ReactiveUserControl<EditUserViewModel>
 
         ViewModel.CurrentProfilePicture.Save(stream);
 
-        var response = await api.SaveProfilePicture(stream.ToArray());
+        var response = await api.User.SaveProfilePicture(stream.ToArray());
 
         if (!response)
         {
@@ -265,7 +265,7 @@ public partial class EditUserView : ReactiveUserControl<EditUserViewModel>
     {
         if (ViewModel?.CurrentUser == default) return;
 
-        var banner = await Locator.Current.GetService<NorthFox>().GetProfileBannerAsync(ViewModel.CurrentUser.CustomBannerUrl);
+        var banner = await Locator.Current.GetService<NorthFox>().User.GetProfileBannerAsync(ViewModel.CurrentUser.CustomBannerUrl);
 
         if (banner == default) return;
 
@@ -278,7 +278,7 @@ public partial class EditUserView : ReactiveUserControl<EditUserViewModel>
 
         var api = Locator.Current.GetService<NorthFox>();
 
-        var user = await api.GetUserFromLoginToken();
+        var user = await api.User.GetUserFromLoginToken();
 
         if (user == default) return;
 
@@ -289,7 +289,7 @@ public partial class EditUserView : ReactiveUserControl<EditUserViewModel>
 
         if (ViewModel?.CurrentUser == default) return;
 
-        var banner = await api.GetProfileBannerAsync(ViewModel.CurrentUser.CustomBannerUrl);
+        var banner = await api.User.GetProfileBannerAsync(ViewModel.CurrentUser.CustomBannerUrl);
 
         if (banner == default)
         {
@@ -312,7 +312,7 @@ public partial class EditUserView : ReactiveUserControl<EditUserViewModel>
             return;
         }
 
-        var response = await Locator.Current.GetService<NorthFox>().DeleteUser();
+        var response = await Locator.Current.GetService<NorthFox>().User.DeleteUser();
 
         if (!response)
         {

--- a/OsuPlayer/Views/EditUserViewModel.cs
+++ b/OsuPlayer/Views/EditUserViewModel.cs
@@ -139,7 +139,7 @@ public class EditUserViewModel : BaseViewModel
             if (cancellationToken.IsCancellationRequested)
                 cancellationToken.ThrowIfCancellationRequested();
 
-            var stats = await Locator.Current.GetService<NorthFox>().GetBeatmapsPlayedByUser(CurrentUser.UniqueId);
+            var stats = await Locator.Current.GetService<NorthFox>().Beatmap.GetBeatmapsPlayedByUser(CurrentUser.UniqueId);
 
             if (cancellationToken.IsCancellationRequested)
                 cancellationToken.ThrowIfCancellationRequested();
@@ -171,7 +171,7 @@ public class EditUserViewModel : BaseViewModel
             if (cancellationToken.IsCancellationRequested)
                 cancellationToken.ThrowIfCancellationRequested();
 
-            var profilePicture = await Locator.Current.GetService<NorthFox>().GetProfilePictureAsync(CurrentUser.UniqueId);
+            var profilePicture = await Locator.Current.GetService<NorthFox>().User.GetProfilePictureAsync(CurrentUser.UniqueId);
 
             if (cancellationToken.IsCancellationRequested)
                 cancellationToken.ThrowIfCancellationRequested();
@@ -203,7 +203,7 @@ public class EditUserViewModel : BaseViewModel
             if (cancellationToken.IsCancellationRequested)
                 cancellationToken.ThrowIfCancellationRequested();
 
-            var banner = await Locator.Current.GetService<NorthFox>().GetProfileBannerAsync(CurrentUser.CustomBannerUrl);
+            var banner = await Locator.Current.GetService<NorthFox>().User.GetProfileBannerAsync(CurrentUser.CustomBannerUrl);
 
             if (cancellationToken.IsCancellationRequested)
                 cancellationToken.ThrowIfCancellationRequested();

--- a/OsuPlayer/Views/HomeViewModel.cs
+++ b/OsuPlayer/Views/HomeViewModel.cs
@@ -155,6 +155,6 @@ public class HomeViewModel : BaseViewModel
     {
         if (CurrentUser == default || CurrentUser.UniqueId == Guid.Empty) return default;
 
-        return await Locator.Current.GetService<NorthFox>().GetProfilePictureAsync(CurrentUser.UniqueId);
+        return await Locator.Current.GetService<NorthFox>().User.GetProfilePictureAsync(CurrentUser.UniqueId);
     }
 }

--- a/OsuPlayer/Views/StatisticsViewModel.cs
+++ b/OsuPlayer/Views/StatisticsViewModel.cs
@@ -122,7 +122,7 @@ public class StatisticsViewModel : BaseViewModel
 
     private async Task UpdateApiStatistics()
     {
-        var statistics = await Locator.Current.GetService<NorthFox>().GetApiStatistics();
+        var statistics = await Locator.Current.GetService<NorthFox>().ApiStatistics.GetApiStatistics();
 
         Users = statistics.TotalUsers;
         Translators = statistics.TotalTranslators;
@@ -134,11 +134,11 @@ public class StatisticsViewModel : BaseViewModel
 
     private async Task UpdateStorageAmount()
     {
-        MbUsed = (float) await Locator.Current.GetService<NorthFox>().GetStorageAmount();
+        MbUsed = (float) await Locator.Current.GetService<NorthFox>().ApiStatistics.GetStorageAmount();
     }
 
     private async Task UpdateBeatmapCount()
     {
-        BeatmapsTracked = (await Locator.Current.GetService<NorthFox>().GetApiStatistics()).TotalBeatmaps;
+        BeatmapsTracked = (await Locator.Current.GetService<NorthFox>().ApiStatistics.GetApiStatistics()).TotalBeatmaps;
     }
 }

--- a/OsuPlayer/Views/UserViewModel.cs
+++ b/OsuPlayer/Views/UserViewModel.cs
@@ -151,7 +151,7 @@ public class UserViewModel : BaseViewModel
     {
         Disposable.Create(() => { }).DisposeWith(disposables);
 
-        Users = (await Locator.Current.GetService<NorthFox>().GetAllUsers())
+        Users = (await Locator.Current.GetService<NorthFox>().User.GetAllUsers())
             ?.Select(x => new User(x))
             .ToObservableCollection() ?? new ObservableCollection<User>();
 
@@ -247,7 +247,7 @@ public class UserViewModel : BaseViewModel
             if (cancellationToken.IsCancellationRequested)
                 cancellationToken.ThrowIfCancellationRequested();
 
-            var stats = await Locator.Current.GetService<NorthFox>().GetBeatmapsPlayedByUser(SelectedUser.UniqueId);
+            var stats = await Locator.Current.GetService<NorthFox>().Beatmap.GetBeatmapsPlayedByUser(SelectedUser.UniqueId);
 
             if (cancellationToken.IsCancellationRequested)
                 cancellationToken.ThrowIfCancellationRequested();
@@ -279,7 +279,7 @@ public class UserViewModel : BaseViewModel
             if (cancellationToken.IsCancellationRequested)
                 cancellationToken.ThrowIfCancellationRequested();
 
-            var profilePicture = await Locator.Current.GetService<NorthFox>().GetProfilePictureAsync(SelectedUser.UniqueId);
+            var profilePicture = await Locator.Current.GetService<NorthFox>().User.GetProfilePictureAsync(SelectedUser.UniqueId);
 
             if (cancellationToken.IsCancellationRequested)
                 cancellationToken.ThrowIfCancellationRequested();
@@ -311,7 +311,7 @@ public class UserViewModel : BaseViewModel
             if (cancellationToken.IsCancellationRequested)
                 cancellationToken.ThrowIfCancellationRequested();
 
-            var banner = await Locator.Current.GetService<NorthFox>().GetProfileBannerAsync(SelectedUser.CustomBannerUrl);
+            var banner = await Locator.Current.GetService<NorthFox>().User.GetProfileBannerAsync(SelectedUser.CustomBannerUrl);
 
             if (cancellationToken.IsCancellationRequested)
                 cancellationToken.ThrowIfCancellationRequested();
@@ -336,7 +336,7 @@ public class UserViewModel : BaseViewModel
     {
         if (SelectedUser == default || SelectedUser.UniqueId == Guid.Empty) return;
 
-        var data = await Locator.Current.GetService<NorthFox>().GetActivityOfUser(SelectedUser.UniqueId);
+        var data = await Locator.Current.GetService<NorthFox>().User.GetActivityOfUser(SelectedUser.UniqueId);
 
         if (data == default) return;
 

--- a/OsuPlayer/Windows/CreateProfileWindow.axaml.cs
+++ b/OsuPlayer/Windows/CreateProfileWindow.axaml.cs
@@ -50,7 +50,7 @@ public partial class CreateProfileWindow : ReactiveWindow<CreateProfileWindowVie
             return;
         }
 
-        var response = await Locator.Current.GetService<NorthFox>().Register(new AddUserModel
+        var response = await Locator.Current.GetService<NorthFox>().User.Register(new AddUserModel
         {
             Username = ViewModel.Username,
             Password = ViewModel.Password


### PR DESCRIPTION
Instead of having one partial `NorthFox` class we now have only one non partial `NorthFox` class.
Therefor you can't access all Methods inside it via the `NorthFox` object. I added some properties for every endpoint to it that you need to call now.

For example instead of writing `northfox.GetBeatmapsPlayedByUser()` you now have to call `northfox.Beatmap.GetBeatmapsPlayedByUser()`.

I find this more appealing as you don't get overwhelmed by one huge list of available methods, were you don't even know to which API endpoint it belongs without looking inside the class itself. Now you know to which endpoint it belongs and what endpoints are available.