### PR TITLE
Discord RPC displays time left instead of time elapsed

### DIFF
--- a/OsuPlayer.Network/Discord/DiscordClient.cs
+++ b/OsuPlayer.Network/Discord/DiscordClient.cs
@@ -60,8 +60,6 @@ public class DiscordClient
             }
         });
 
-        _client.Invoke();
-
         return this;
     }
 
@@ -85,23 +83,23 @@ public class DiscordClient
     /// <param name="state">Text of the second line</param>
     /// <param name="beatmapSetId">Optional beatmapset ID</param>
     /// <param name="assets">Optional assets to use</param>
-    public async Task UpdatePresence(string details, string state, int beatmapSetId = 0, Assets? assets = null)
+    public async Task UpdatePresence(string details, string state, int beatmapSetId = 0, Assets? assets = null, TimeSpan? durationLeft = null)
     {
         if (assets == null && beatmapSetId != 0)
         {
             assets = await TryToGetThumbnail(beatmapSetId);
         }
+
+        var timestamps = durationLeft == null ? null : Timestamps.FromTimeSpan(durationLeft.Value);
         
         _client.SetPresence(new RichPresence
         {
             Details = details,
             State = state,
             Assets = assets ?? _defaultAssets,
-            Timestamps = Timestamps.Now,
-            Buttons = GetButtons()
+            Buttons = GetButtons(),
+            Timestamps = timestamps
         });
-
-        _client.Invoke();
     }
 
     private async Task<Assets?> TryToGetThumbnail(int beatmapSetId)

--- a/OsuPlayer.Network/Discord/DiscordClient.cs
+++ b/OsuPlayer.Network/Discord/DiscordClient.cs
@@ -83,6 +83,7 @@ public class DiscordClient
     /// <param name="state">Text of the second line</param>
     /// <param name="beatmapSetId">Optional beatmapset ID</param>
     /// <param name="assets">Optional assets to use</param>
+    /// <param name="durationLeft">Optional duration left that is displayed in the RPC</param>
     public async Task UpdatePresence(string details, string state, int beatmapSetId = 0, Assets? assets = null, TimeSpan? durationLeft = null)
     {
         if (assets == null && beatmapSetId != 0)

--- a/OsuPlayer/Modules/Audio/Engine/BassEngine.cs
+++ b/OsuPlayer/Modules/Audio/Engine/BassEngine.cs
@@ -35,6 +35,7 @@ public sealed class BassEngine : IAudioEngine
     public Bindable<double> ChannelPosition { get; } = new();
     public Bindable<double> Volume { get; } = new();
     public Bindable<bool> IsPlaying { get; } = new();
+    public Bindable<double> PlaybackSpeed { get; } = new();
 
     public bool IsEqEnabled
     {
@@ -200,6 +201,8 @@ public sealed class BassEngine : IAudioEngine
     private void SetPlaybackSpeedOptions(double speed)
     {
         using var config = new Config();
+
+        PlaybackSpeed.Value = speed;
 
         if (config.Container.UsePitch)
         {

--- a/OsuPlayer/Modules/Audio/Interfaces/IAudioEngine.cs
+++ b/OsuPlayer/Modules/Audio/Interfaces/IAudioEngine.cs
@@ -9,5 +9,6 @@ public interface IAudioEngine : ICanOpenFiles, ICommonFeatures
 
     public Bindable<double> ChannelLength { get; }
     public Bindable<double> ChannelPosition { get; }
+    public Bindable<double> PlaybackSpeed { get; }
     public ChannelReachedEndHandler ChannelReachedEnd { set; }
 }


### PR DESCRIPTION
Implements #220 

- When a user plays a song now it displays the song left time.
- When the user pauses the playback it hides the time left
- It also supports all playback speeds and the time left updates accordingly to the playbackspeed updates