### PR TITLE
Discord Client as Service and fixing unnessary thumbnail requests

### DIFF
--- a/OsuPlayer.Interfaces/OsuPlayer.Interfaces.csproj
+++ b/OsuPlayer.Interfaces/OsuPlayer.Interfaces.csproj
@@ -13,6 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="DiscordRichPresence" Version="1.2.1.24" />
         <PackageReference Include="Founntain.Nein" Version="2023.1018.2" />
         <PackageReference Include="LiveChartsCore" Version="2.0.0-beta.101" />
         <PackageReference Include="OsuPlayer.Api.Data" Version="1.0.10" />

--- a/OsuPlayer.Interfaces/Service/IDiscordService.cs
+++ b/OsuPlayer.Interfaces/Service/IDiscordService.cs
@@ -1,0 +1,10 @@
+﻿using DiscordRPC;
+
+namespace OsuPlayer.Interfaces.Service;
+
+public interface IDiscordService
+{
+    public void Initialize();
+    public void DeInitialize();
+    public Task UpdatePresence(string details, string state, int beatmapSetId = 0, Assets? assets = null, TimeSpan? durationLeft = null);
+}

--- a/OsuPlayer.Network/OsuPlayer.Network.csproj
+++ b/OsuPlayer.Network/OsuPlayer.Network.csproj
@@ -8,7 +8,6 @@
 
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="0.10.22" />
-        <PackageReference Include="DiscordRichPresence" Version="1.2.1.24" />
         <PackageReference Include="Founntain.Nein" Version="2023.1018.2" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Octokit" Version="7.1.0" />
@@ -19,5 +18,9 @@
         <ProjectReference Include="..\OsuPlayer.Data\OsuPlayer.Data.csproj" />
         <ProjectReference Include="..\OsuPlayer.Interfaces\OsuPlayer.Interfaces.csproj" />
         <ProjectReference Include="..\OsuPlayer.IO\OsuPlayer.IO.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Discord\" />
     </ItemGroup>
 </Project>

--- a/OsuPlayer.Services/OsuPlayer.Services.csproj
+++ b/OsuPlayer.Services/OsuPlayer.Services.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="DiscordRichPresence" Version="1.2.1.24" />
         <PackageReference Include="Founntain.Nein" Version="2023.1018.2" />
         <PackageReference Include="LiveChartsCore" Version="2.0.0-beta.101" />
         <PackageReference Include="OsuPlayer.Api.Data" Version="1.0.10" />

--- a/OsuPlayer.Services/OsuPlayerService.cs
+++ b/OsuPlayer.Services/OsuPlayerService.cs
@@ -16,7 +16,7 @@ public abstract class OsuPlayerService : IOsuPlayerService
 
             LogToConsole("Service initialized.", LogType.Success, includeLogTypeTag: false);
         }
-        catch (Exception _)
+        catch (Exception)
         {
             LogToConsole($"Service initialized, but couldn't initialize with encoding {Encoding.UTF8.EncodingName}.", LogType.Warning, includeLogTypeTag: false);
         }

--- a/OsuPlayer.Services/ProfileManagerService.cs
+++ b/OsuPlayer.Services/ProfileManagerService.cs
@@ -5,7 +5,7 @@ using Splat;
 
 namespace OsuPlayer.Services;
 
-public class ProfileManagerServiceService : IProfileManagerService
+public class ProfileManagerService : IProfileManagerService
 {
     public User? User { get; set; }
 

--- a/OsuPlayer/Program.cs
+++ b/OsuPlayer/Program.cs
@@ -82,12 +82,12 @@ internal static class Program
         services.RegisterLazySingleton<IPlayer>(() => new Player(
             audioEngine: resolver.GetRequiredService<IAudioEngine>(),
             songSourceProvider: resolver.GetRequiredService<ISongSourceProvider>(),
-            shuffleProvider: resolver.GetRequiredService<IShuffleServiceProvider>(),
-            statisticsProvider: resolver.GetRequiredService<IStatisticsProvider>(),
-            sortProvider: resolver.GetRequiredService<ISortProvider>(),
-            historyProvider: resolver.GetRequiredService<IHistoryProvider>(),
-            discordService: resolver.GetRequiredService<IDiscordService>(),
-            lastFmApi: resolver.GetRequiredService<ILastFmApiService>()
+            shuffleProvider: resolver.GetService<IShuffleServiceProvider>(),
+            statisticsProvider: resolver.GetService<IStatisticsProvider>(),
+            sortProvider: resolver.GetService<ISortProvider>(),
+            historyProvider: resolver.GetService<IHistoryProvider>(),
+            discordService: resolver.GetService<IDiscordService>(),
+            lastFmApi: resolver.GetService<ILastFmApiService>()
         ));
 
         services.Register(() => new MainWindowViewModel(

--- a/OsuPlayer/Program.cs
+++ b/OsuPlayer/Program.cs
@@ -73,23 +73,11 @@ internal static class Program
 
     private static void Register(IMutableDependencyResolver services, IReadonlyDependencyResolver resolver, IRuntimePlatform platform)
     {
-        services.RegisterLazySingleton<ILoggingService>(() => new LoggingService());
-
         services.RegisterLazySingleton<IAudioEngine>(() => new BassEngine());
 
         services.RegisterLazySingleton<IDbReaderFactory>(() => new DbReaderFactory());
 
-        services.RegisterLazySingleton<IDiscordService>(() => new DiscordService());
-
-        services.RegisterLazySingleton<IProfileManagerService>(() => new ProfileManagerServiceService());
-        services.RegisterLazySingleton<IShuffleServiceProvider>(() => new ShuffleService());
-        services.RegisterLazySingleton<IStatisticsProvider>(() => new ApiStatisticsService(resolver.GetService<IProfileManagerService>()));
-        services.RegisterLazySingleton<ISortProvider>(() => new SortService());
-        services.RegisterLazySingleton<ISongSourceProvider>(() => new OsuSongSourceService(resolver.GetService<ISortProvider>()));
-        services.RegisterLazySingleton<IHistoryProvider>(() => new HistoryService());
-        services.RegisterLazySingleton<ILastFmApiService>(() => new LastFmService(new LastFmApi()));
-
-        services.RegisterLazySingleton<IOsuPlayerApiService>(() => new NorthFox());
+        RegisterServices(services, resolver);
 
         services.RegisterLazySingleton<IPlayer>(() => new Player(
             audioEngine: resolver.GetRequiredService<IAudioEngine>(),
@@ -114,5 +102,21 @@ internal static class Program
         services.RegisterLazySingleton(() => new MainWindow(
             resolver.GetRequiredService<MainWindowViewModel>(),
             resolver.GetRequiredService<ILoggingService>()));
+    }
+
+    private static void RegisterServices(IMutableDependencyResolver services, IReadonlyDependencyResolver resolver)
+    {
+        services.RegisterLazySingleton<ILoggingService>(() => new LoggingService());
+
+        services.RegisterLazySingleton<IDiscordService>(() => new DiscordService());
+        services.RegisterLazySingleton<IProfileManagerService>(() => new ProfileManagerService());
+        services.RegisterLazySingleton<IShuffleServiceProvider>(() => new ShuffleService());
+        services.RegisterLazySingleton<IStatisticsProvider>(() => new ApiStatisticsService(resolver.GetService<IProfileManagerService>()));
+        services.RegisterLazySingleton<ISortProvider>(() => new SortService());
+        services.RegisterLazySingleton<ISongSourceProvider>(() => new OsuSongSourceService(resolver.GetService<ISortProvider>()));
+        services.RegisterLazySingleton<IHistoryProvider>(() => new HistoryService());
+        services.RegisterLazySingleton<ILastFmApiService>(() => new LastFmService(new LastFmApi()));
+
+        services.RegisterLazySingleton<IOsuPlayerApiService>(() => new NorthFox());
     }
 }

--- a/OsuPlayer/Program.cs
+++ b/OsuPlayer/Program.cs
@@ -79,6 +79,8 @@ internal static class Program
 
         services.RegisterLazySingleton<IDbReaderFactory>(() => new DbReaderFactory());
 
+        services.RegisterLazySingleton<IDiscordService>(() => new DiscordService());
+
         services.RegisterLazySingleton<IProfileManagerService>(() => new ProfileManagerServiceService());
         services.RegisterLazySingleton<IShuffleServiceProvider>(() => new ShuffleService());
         services.RegisterLazySingleton<IStatisticsProvider>(() => new ApiStatisticsService(resolver.GetService<IProfileManagerService>()));
@@ -96,6 +98,7 @@ internal static class Program
             statisticsProvider: resolver.GetRequiredService<IStatisticsProvider>(),
             sortProvider: resolver.GetRequiredService<ISortProvider>(),
             historyProvider: resolver.GetRequiredService<IHistoryProvider>(),
+            discordService: resolver.GetRequiredService<IDiscordService>(),
             lastFmApi: resolver.GetRequiredService<ILastFmApiService>()
         ));
 

--- a/OsuPlayer/Views/UserViewModel.cs
+++ b/OsuPlayer/Views/UserViewModel.cs
@@ -379,24 +379,24 @@ public class UserViewModel : BaseViewModel
     {
         return new List<IControl>();
 
-        if (currentUser == default) return default!;
-
-        var badges = new List<MaterialIcon>();
-
-        var size = 32;
-
-        foreach (var badge in currentUser.Badges)
-        {
-            var materialIcon = new MaterialIcon
-            {
-                Kind = (MaterialIconKind) badge.Icon,
-                Height = size,
-                Width = size
-            };
-
-            badges.Add(materialIcon);
-        }
-
-        return badges;
+        // if (currentUser == default) return default!;
+        //
+        // var badges = new List<MaterialIcon>();
+        //
+        // var size = 32;
+        //
+        // foreach (var badge in currentUser.Badges)
+        // {
+        //     var materialIcon = new MaterialIcon
+        //     {
+        //         Kind = (MaterialIconKind) badge.Icon,
+        //         Height = size,
+        //         Width = size
+        //     };
+        //
+        //     badges.Add(materialIcon);
+        // }
+        //
+        // return badges;
     }
 }


### PR DESCRIPTION
As the description says the DiscordClient now is it's own Service and can be used as such.

- Also fixed a bug, that the DiscordClient would always make a request to the osu! thumbnail url, when changing the timestamp of a song.