### PR TITLE
Fixed Unicode handling in song titles and artists

### DIFF
--- a/OsuPlayer.Data/DataModels/DbMapEntry.cs
+++ b/OsuPlayer.Data/DataModels/DbMapEntry.cs
@@ -9,19 +9,16 @@ namespace OsuPlayer.Data.DataModels;
 /// </summary>
 public class DbMapEntry : DbMapEntryBase, IMapEntry
 {
-    public string ArtistUnicode { get; init; } = string.Empty;
-    public string TitleUnicode { get; init; } = string.Empty;
     public string AudioFileName { get; init; } = string.Empty;
     public string FolderName { get; init; } = string.Empty;
     public string FolderPath { get; init; } = string.Empty;
     public string FullPath { get; init; } = string.Empty;
-    public bool UseUnicode { get; set; }
 
     public async Task<string?> FindBackground()
     {
         var eventCount = 0;
 
-        if (string.IsNullOrEmpty(FolderPath))
+        if (string.IsNullOrWhiteSpace(FolderPath))
             return null;
 
         string[] files;
@@ -64,26 +61,12 @@ public class DbMapEntry : DbMapEntryBase, IMapEntry
                 break;
             }
 
-        if (string.IsNullOrEmpty(background))
+        if (string.IsNullOrWhiteSpace(background))
             return null;
 
         var fileName = background.Split(',')[2].Replace("\"", string.Empty);
         var path = Path.Combine(FolderPath, fileName);
 
         return File.Exists(path) ? path : null;
-    }
-
-    public override string GetArtist()
-    {
-        if (UseUnicode)
-            return string.IsNullOrEmpty(ArtistUnicode) ? Artist : ArtistUnicode;
-        return Artist;
-    }
-
-    public override string GetTitle()
-    {
-        if (UseUnicode)
-            return string.IsNullOrEmpty(TitleUnicode) ? Title : TitleUnicode;
-        return Title;
     }
 }

--- a/OsuPlayer.Data/DataModels/DbMapEntryBase.cs
+++ b/OsuPlayer.Data/DataModels/DbMapEntryBase.cs
@@ -14,7 +14,9 @@ public class DbMapEntryBase : IMapEntryBase
     public long DbOffset { get; init; }
     public string? OsuPath { get; init; }
     public string Artist { get; init; } = string.Empty;
+    public string ArtistUnicode { get; init; } = string.Empty;
     public string Title { get; init; } = string.Empty;
+    public string TitleUnicode { get; init; } = string.Empty;
     public string Hash { get; init; } = string.Empty;
     public int BeatmapSetId { get; init; }
     public int TotalTime { get; init; }
@@ -22,24 +24,27 @@ public class DbMapEntryBase : IMapEntryBase
     public string SongName => GetSongName();
     public string ArtistString => GetArtist();
     public string TitleString => GetTitle();
+    public bool UseUnicode { get; set; }
 
     /// <summary>
     /// Gets the artist
-    /// <remarks>may be overridden for usage with <see cref="DbMapEntry.UseUnicode" /></remarks>
     /// </summary>
     /// <returns>the artist</returns>
-    public virtual string GetArtist()
+    public string GetArtist()
     {
+        if (UseUnicode)
+            return string.IsNullOrWhiteSpace(ArtistUnicode) ? Artist : ArtistUnicode;
         return Artist;
     }
 
     /// <summary>
     /// Gets the title
-    /// <remarks>may be overridden for usage with <see cref="DbMapEntry.UseUnicode" /></remarks>
     /// </summary>
     /// <returns>the title</returns>
-    public virtual string GetTitle()
+    public string GetTitle()
     {
+        if (UseUnicode)
+            return string.IsNullOrWhiteSpace(TitleUnicode) ? Title : TitleUnicode;
         return Title;
     }
 

--- a/OsuPlayer.Data/DataModels/Interfaces/IMapEntry.cs
+++ b/OsuPlayer.Data/DataModels/Interfaces/IMapEntry.cs
@@ -2,13 +2,10 @@
 
 public interface IMapEntry : IMapEntryBase
 {
-    public string ArtistUnicode { get; }
-    public string TitleUnicode { get; }
     public string AudioFileName { get; }
     public string FolderName { get; }
     public string FolderPath { get; }
     public string FullPath { get; }
-    public bool UseUnicode { get; set; }
 
     /// <summary>
     /// Gets the background image of this <see cref="IMapEntry" />

--- a/OsuPlayer.Data/DataModels/Interfaces/IMapEntryBase.cs
+++ b/OsuPlayer.Data/DataModels/Interfaces/IMapEntryBase.cs
@@ -7,7 +7,9 @@ public interface IMapEntryBase : IEquatable<IMapEntryBase>, IComparable<IMapEntr
     public IDbReaderFactory DbReaderFactory { get; init; }
 
     public string Artist { get; }
+    public string ArtistUnicode { get; }
     public string Title { get; }
+    public string TitleUnicode { get; }
     public string Hash { get; }
     public int BeatmapSetId { get; }
     public int TotalTime { get; }
@@ -15,6 +17,8 @@ public interface IMapEntryBase : IEquatable<IMapEntryBase>, IComparable<IMapEntr
     public string SongName => GetSongName();
     public string ArtistString => GetArtist();
     public string TitleString => GetTitle();
+
+    public bool UseUnicode { get; set; }
 
     public string GetArtist();
 

--- a/OsuPlayer.Data/DataModels/RealmMapEntry.cs
+++ b/OsuPlayer.Data/DataModels/RealmMapEntry.cs
@@ -9,29 +9,10 @@ namespace OsuPlayer.Data.DataModels;
 public class RealmMapEntry : RealmMapEntryBase, IMapEntry
 {
     public string BackgroundFileLocation { get; init; } = string.Empty;
-    public string ArtistUnicode { get; init; } = string.Empty;
-    public string TitleUnicode { get; init; } = string.Empty;
     public string AudioFileName { get; init; } = string.Empty;
     public string FolderName { get; init; } = string.Empty;
     public string FolderPath { get; init; } = string.Empty;
     public string FullPath { get; init; } = string.Empty;
-    public bool UseUnicode { get; set; }
-
-    public override string GetArtist()
-    {
-        if (UseUnicode)
-            return string.IsNullOrEmpty(ArtistUnicode) ? Artist : ArtistUnicode;
-
-        return Artist;
-    }
-
-    public override string GetTitle()
-    {
-        if (UseUnicode)
-            return string.IsNullOrEmpty(TitleUnicode) ? Title : TitleUnicode;
-
-        return Title;
-    }
 
     public Task<string?> FindBackground()
     {

--- a/OsuPlayer.Data/DataModels/RealmMapEntryBase.cs
+++ b/OsuPlayer.Data/DataModels/RealmMapEntryBase.cs
@@ -14,7 +14,9 @@ public class RealmMapEntryBase : IMapEntryBase
     public Guid Id { get; init; }
     public string? OsuPath { get; init; }
     public string Artist { get; init; } = string.Empty;
+    public string ArtistUnicode { get; init; } = string.Empty;
     public string Title { get; init; } = string.Empty;
+    public string TitleUnicode { get; init; } = string.Empty;
     public string Hash { get; init; } = string.Empty;
     public int BeatmapSetId { get; init; }
     public int TotalTime { get; init; }
@@ -22,14 +24,29 @@ public class RealmMapEntryBase : IMapEntryBase
     public string SongName => GetSongName();
     public string ArtistString => GetArtist();
     public string TitleString => GetTitle();
+    public bool UseUnicode { get; set; }
 
-    public virtual string GetArtist()
+    /// <summary>
+    /// Gets the artist
+    /// <remarks>may be overridden for usage with <see cref="DbMapEntry.UseUnicode" /></remarks>
+    /// </summary>
+    /// <returns>the artist</returns>
+    public string GetArtist()
     {
+        if (UseUnicode)
+            return string.IsNullOrWhiteSpace(ArtistUnicode) ? Artist : ArtistUnicode;
         return Artist;
     }
 
-    public virtual string GetTitle()
+    /// <summary>
+    /// Gets the title
+    /// <remarks>may be overridden for usage with <see cref="DbMapEntry.UseUnicode" /></remarks>
+    /// </summary>
+    /// <returns>the title</returns>
+    public string GetTitle()
     {
+        if (UseUnicode)
+            return string.IsNullOrWhiteSpace(TitleUnicode) ? Title : TitleUnicode;
         return Title;
     }
 

--- a/OsuPlayer.IO/DbReader/RealmReader.cs
+++ b/OsuPlayer.IO/DbReader/RealmReader.cs
@@ -3,6 +3,7 @@ using OsuPlayer.Data.DataModels.Interfaces;
 using OsuPlayer.Data.LazerModels.Beatmaps;
 using OsuPlayer.Data.LazerModels.Collections;
 using OsuPlayer.Data.LazerModels.Files;
+using OsuPlayer.IO.Storage.Config;
 using Realms;
 using Realms.Dynamic;
 using Splat;
@@ -103,6 +104,8 @@ public class RealmReader : IDatabaseReader
         var audioFolderName = Path.Combine($"{audioHash[0]}", $"{audioHash[0]}{audioHash[1]}");
         var backgroundFolderName = Path.Combine($"{backgroundHash?[0]}", $"{backgroundHash?[0]}{backgroundHash?[1]}");
 
+        using var config = new Config();
+
         var newMap = new RealmMapEntry
         {
             DbReaderFactory = _readerFactory,
@@ -120,7 +123,8 @@ public class RealmReader : IDatabaseReader
             BeatmapSetId = mapEntryBase.BeatmapSetId,
             FolderName = audioFolderName,
             FolderPath = Path.Combine("files", audioFolderName),
-            FullPath = Path.Combine(path, "files", audioFolderName, audioHash)
+            FullPath = Path.Combine(path, "files", audioFolderName, audioHash),
+            UseUnicode = config.Container.UseSongNameUnicode
         };
 
         _realm.Dispose();
@@ -130,6 +134,8 @@ public class RealmReader : IDatabaseReader
 
     public Task<List<IMapEntryBase>?> ReadBeatmaps()
     {
+        using var config = new Config();
+
         var minBeatMaps = new List<IMapEntryBase>();
 
         var beatmaps = _realm.DynamicApi.All("BeatmapSet").ToList().OfType<DynamicRealmObject>().ToList();
@@ -156,7 +162,8 @@ public class RealmReader : IDatabaseReader
                 BeatmapSetId = beatmapSetId,
                 Title = title,
                 TotalTime = (int) totalTime,
-                Id = id
+                Id = id,
+                UseUnicode = config.Container.UseSongNameUnicode
             });
         }
 

--- a/OsuPlayer/Views/PlayerControlViewModel.cs
+++ b/OsuPlayer/Views/PlayerControlViewModel.cs
@@ -136,7 +136,7 @@ public class PlayerControlViewModel : BaseViewModel
 
     public bool IsPlaying => _isPlaying.Value;
 
-    public string TitleText => CurrentSong.Value?.Title ?? "No song is playing";
+    public string TitleText => CurrentSong.Value?.GetTitle() ?? "No song is playing";
 
     public RepeatMode IsRepeating
     {
@@ -148,7 +148,7 @@ public class PlayerControlViewModel : BaseViewModel
         }
     }
 
-    public string ArtistText => CurrentSong.Value?.Artist ?? "please select from song list";
+    public string ArtistText => CurrentSong.Value?.GetArtist() ?? "please select from song list";
 
     public string SongText => $"{ArtistText} - {TitleText}";
 

--- a/OsuPlayer/Views/SettingsView.axaml
+++ b/OsuPlayer/Views/SettingsView.axaml
@@ -135,31 +135,33 @@
                                      Description="Settings for the visual appearance, make it your own~"
                                      Name="VisualSettingsExpander">
 
-                    <ui:SettingsExpanderItem Content="App Theme"
-                                             Description="Do you prefer the dark or light side? Or let your system decide">
+                    <ui:SettingsExpanderItem Content="App Theme" Description="Do you prefer the dark or light side? Or let your system decide">
                         <ui:SettingsExpanderItem.Footer>
                             <ui:FAComboBox ItemsSource="{Binding AppThemes}" SelectedItem="{Binding CurrentAppTheme}" />
+                        </ui:SettingsExpanderItem.Footer>
+                    </ui:SettingsExpanderItem>
+
+                    <ui:SettingsExpanderItem Content="Display titles and artists in unicode" Description="Shows titles and artists in their respective unicode characters e.g. japanese (this also means you have to search in unicode). Requires restart to work properly">
+                        <ui:SettingsExpanderItem.Footer>
+                            <ToggleSwitch IsChecked="{Binding UseSongNameUnicode}" OnContent="Yes" OffContent="No" />
                         </ui:SettingsExpanderItem.Footer>
                     </ui:SettingsExpanderItem>
 
                     <ui:SettingsExpanderItem Content="Navigation Position"
                                              Description="Do you want to have the navigation on the left or top?">
                         <ui:SettingsExpanderItem.Footer>
-                            <ToggleSwitch IsChecked="{Binding UseLeftNavigationPosition}" OnContent="Left"
-                                          OffContent="Top" />
+                            <ToggleSwitch IsChecked="{Binding UseLeftNavigationPosition}" OnContent="Left" OffContent="Top" />
                         </ui:SettingsExpanderItem.Footer>
                     </ui:SettingsExpanderItem>
 
-                    <ui:SettingsExpanderItem Content="Image Rendering Mode"
-                                             Description="Tell the application at which quality you want to render images e.g. profile pictures, banners etc. Requires restart to work">
+                    <ui:SettingsExpanderItem Content="Image Rendering Mode" Description="Tell the application at which quality you want to render images e.g. profile pictures, banners etc. Requires restart to work">
                         <ui:SettingsExpanderItem.Footer>
                             <ui:FAComboBox ItemsSource="{Binding RenderingModes}"
                                            SelectedItem="{Binding RenderingMode}" />
                         </ui:SettingsExpanderItem.Footer>
                     </ui:SettingsExpanderItem>
 
-                    <ui:SettingsExpanderItem Content="Display Audio Visualizer"
-                                             Description="If enabled it displays an audio visualizer on the bottom of the window (and miniplayer). Increases GPU usage">
+                    <ui:SettingsExpanderItem Content="Display Audio Visualizer" Description="If enabled it displays an audio visualizer on the bottom of the window (and miniplayer). Increases GPU usage">
                         <ui:SettingsExpanderItem.Footer>
                             <ToggleSwitch IsChecked="{Binding DisplayAudioVisualizer}" OnContent="On" OffContent="Off" />
                         </ui:SettingsExpanderItem.Footer>
@@ -186,8 +188,7 @@
                     <!--     </ui:SettingsExpanderItem.Footer> -->
                     <!-- </ui:SettingsExpanderItem> -->
 
-                    <ui:SettingsExpanderItem Content="Window Background Method"
-                                             Description="The method that should be used for the window background">
+                    <ui:SettingsExpanderItem Content="Window Background Method" Description="The method that should be used for the window background">
                         <ui:SettingsExpanderItem.Footer>
                             <ui:FAComboBox ItemsSource="{Binding BackgroundModes}"
                                            SelectedItem="{Binding BackgroundMode}" />

--- a/OsuPlayer/Windows/MiniplayerViewModel.cs
+++ b/OsuPlayer/Windows/MiniplayerViewModel.cs
@@ -103,7 +103,7 @@ public class MiniplayerViewModel : BaseWindowViewModel
 
     public bool IsPlaying => _isPlaying.Value;
 
-    public string TitleText => CurrentSong.Value?.Title ?? "No song is playing";
+    public string TitleText => CurrentSong.Value?.GetTitle() ?? "No song is playing";
 
     public RepeatMode IsRepeating
     {
@@ -115,7 +115,7 @@ public class MiniplayerViewModel : BaseWindowViewModel
         }
     }
 
-    public string ArtistText => CurrentSong.Value?.Artist ?? "please select from song list";
+    public string ArtistText => CurrentSong.Value?.GetArtist() ?? "please select from song list";
 
     public string SongText => $"{ArtistText} - {TitleText}";
 


### PR DESCRIPTION
Removed Unicode handling from specific MapEntry classes and centralized it in MapEntryBase class. Also added an option in the settings to allow users to display titles and artists using their respective Unicode characters. This gives users more display options. Fixes #274 

New Setting:
![327962008-30157397-0bae-497f-948a-27795cc555cc](https://github.com/Founntain/osuplayer/assets/28785685/59f7c2b9-04cb-41ac-9a40-edaf227af48b)

Screenshots:
![327961904-01fd2e13-4a93-480f-9e9d-d6a10266a912](https://github.com/Founntain/osuplayer/assets/28785685/2fa4feb3-c141-414c-a589-f0d5f2dd8c86)
![327961930-5bb69d6e-3f17-4f12-8e19-f6308d40fe14](https://github.com/Founntain/osuplayer/assets/28785685/9b0cb15c-f422-405d-96e8-db92083da104)
![327961939-da6ee1b2-9b9e-48c2-8b69-7a5ba4950211](https://github.com/Founntain/osuplayer/assets/28785685/f7cfaa2e-05bb-4132-b724-dc263d7568b6)
