### PR TITLE
Fixed unicode texts not importing on lazer and unicode setting not saving

### DIFF
--- a/OsuPlayer.IO/DbReader/RealmReader.cs
+++ b/OsuPlayer.IO/DbReader/RealmReader.cs
@@ -146,9 +146,11 @@ public class RealmReader : IDatabaseReader
             var firstBeatmap = infos.First().DynamicApi;
             var metadata = firstBeatmap.Get<DynamicRealmObject>(nameof(BeatmapInfo.Metadata)).DynamicApi;
             var artist = metadata.Get<string>(nameof(BeatmapMetadata.Artist));
+            var artistUnicode = metadata.Get<string>(nameof(BeatmapMetadata.ArtistUnicode));
             var hash = firstBeatmap.Get<string>(nameof(BeatmapInfo.MD5Hash));
             var beatmapSetId = dynamicBeatmap.DynamicApi.Get<int>(nameof(BeatmapSetInfo.OnlineID));
             var title = metadata.Get<string>(nameof(BeatmapMetadata.Title));
+            var titleUnicode = metadata.Get<string>(nameof(BeatmapMetadata.TitleUnicode));
 
             var totalTime = infos.Select(x => x.DynamicApi.Get<double>(nameof(BeatmapInfo.Length))).Max();
             var id = dynamicBeatmap.DynamicApi.Get<Guid>(nameof(BeatmapSetInfo.ID));
@@ -158,9 +160,11 @@ public class RealmReader : IDatabaseReader
                 DbReaderFactory = _readerFactory,
                 OsuPath = string.Intern(_path),
                 Artist = string.Intern(artist),
+                ArtistUnicode = string.Intern(artistUnicode),
                 Hash = hash,
                 BeatmapSetId = beatmapSetId,
                 Title = title,
+                TitleUnicode = titleUnicode,
                 TotalTime = (int) totalTime,
                 Id = id,
                 UseUnicode = config.Container.UseSongNameUnicode

--- a/OsuPlayer/Views/SettingsViewModel.cs
+++ b/OsuPlayer/Views/SettingsViewModel.cs
@@ -110,7 +110,7 @@ public class SettingsViewModel : BaseViewModel
 
             using var config = new Config();
 
-            config.Container.UseLeftNavigationPosition = value;
+            config.Container.UseSongNameUnicode = value;
         }
     }
 


### PR DESCRIPTION
The commit includes two new fields, 'ArtistUnicode' and 'TitleUnicode' in the RealmReader. This allows the database to store the Unicode versions of song titles and artists, intended to improve display and searching capabilities for songs with non-Latin character sets. Additionally a bug was fixed, that the setting for displaying the Unicode is not saved properly