### PR TITLE
Fix import crash from missing unicode title/artist in rare cases

### DIFF
--- a/OsuPlayer.IO/DbReader/RealmReader.cs
+++ b/OsuPlayer.IO/DbReader/RealmReader.cs
@@ -163,7 +163,7 @@ public class RealmReader : IDatabaseReader
                 ArtistUnicode = string.Intern(artistUnicode),
                 Hash = hash,
                 BeatmapSetId = beatmapSetId,
-                Title = title,
+                Title = string.Intern(title),
                 TitleUnicode = string.Intern(titleUnicode),
                 TotalTime = (int) totalTime,
                 Id = id,

--- a/OsuPlayer.IO/DbReader/RealmReader.cs
+++ b/OsuPlayer.IO/DbReader/RealmReader.cs
@@ -112,9 +112,9 @@ public class RealmReader : IDatabaseReader
             Id = id.Value,
             OsuPath = string.Intern(path),
             Artist = string.Intern(mapEntryBase.Artist),
-            ArtistUnicode = metadata.Get<string>(nameof(BeatmapMetadata.ArtistUnicode)),
-            Title = mapEntryBase.Title,
-            TitleUnicode = metadata.Get<string>(nameof(BeatmapMetadata.TitleUnicode)),
+            ArtistUnicode = string.Intern(mapEntryBase.ArtistUnicode),
+            Title = string.Intern(mapEntryBase.Title),
+            TitleUnicode = string.Intern(mapEntryBase.TitleUnicode),
             AudioFileName = audioFileName,
             BackgroundFileLocation = string.IsNullOrEmpty(backgroundFolderName)
                 ? string.Empty
@@ -146,11 +146,11 @@ public class RealmReader : IDatabaseReader
             var firstBeatmap = infos.First().DynamicApi;
             var metadata = firstBeatmap.Get<DynamicRealmObject>(nameof(BeatmapInfo.Metadata)).DynamicApi;
             var artist = metadata.Get<string>(nameof(BeatmapMetadata.Artist));
-            var artistUnicode = metadata.Get<string>(nameof(BeatmapMetadata.ArtistUnicode));
+            var artistUnicode = metadata.Get<string>(nameof(BeatmapMetadata.ArtistUnicode)) ?? string.Empty;
             var hash = firstBeatmap.Get<string>(nameof(BeatmapInfo.MD5Hash));
             var beatmapSetId = dynamicBeatmap.DynamicApi.Get<int>(nameof(BeatmapSetInfo.OnlineID));
             var title = metadata.Get<string>(nameof(BeatmapMetadata.Title));
-            var titleUnicode = metadata.Get<string>(nameof(BeatmapMetadata.TitleUnicode));
+            var titleUnicode = metadata.Get<string>(nameof(BeatmapMetadata.TitleUnicode)) ?? string.Empty;
 
             var totalTime = infos.Select(x => x.DynamicApi.Get<double>(nameof(BeatmapInfo.Length))).Max();
             var id = dynamicBeatmap.DynamicApi.Get<Guid>(nameof(BeatmapSetInfo.ID));
@@ -164,7 +164,7 @@ public class RealmReader : IDatabaseReader
                 Hash = hash,
                 BeatmapSetId = beatmapSetId,
                 Title = title,
-                TitleUnicode = titleUnicode,
+                TitleUnicode = string.Intern(titleUnicode),
                 TotalTime = (int) totalTime,
                 Id = id,
                 UseUnicode = config.Container.UseSongNameUnicode

--- a/OsuPlayer/Views/SettingsViewModel.cs
+++ b/OsuPlayer/Views/SettingsViewModel.cs
@@ -9,11 +9,14 @@ using FluentAvalonia.Styling;
 using FluentAvalonia.UI.Controls;
 using Nein.Base;
 using Nein.Controls.Interfaces;
+using Nein.Extensions;
 using OsuPlayer.Api.Data.API.EntityModels;
+using OsuPlayer.Data.DataModels.Interfaces;
 using OsuPlayer.Data.OsuPlayer.Classes;
 using OsuPlayer.Data.OsuPlayer.Enums;
 using OsuPlayer.Extensions.EnumExtensions;
 using OsuPlayer.Interfaces.Service;
+using OsuPlayer.IO.Importer;
 using OsuPlayer.Modules.Audio.Interfaces;
 using OsuPlayer.Network;
 using OsuPlayer.Network.Data;
@@ -111,6 +114,16 @@ public class SettingsViewModel : BaseViewModel
             using var config = new Config();
 
             config.Container.UseSongNameUnicode = value;
+
+            var provider = Locator.Current.GetRequiredService<ISongSourceProvider>();
+
+            provider.SongSource.Edit(mapEntryBases =>
+            {
+                foreach (IMapEntryBase mapEntryBase in mapEntryBases)
+                {
+                    mapEntryBase.UseUnicode = value;
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Also makes switching unicode display in settings happen immediately and not needing a restart