### PR TITLE
Fixed crash on profile picture changes

### DIFF
--- a/OsuPlayer/Views/EditUserView.axaml.cs
+++ b/OsuPlayer/Views/EditUserView.axaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Web;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Media.Imaging;
@@ -55,7 +56,10 @@ public partial class EditUserView : ReactiveUserControl<EditUserViewModel>
 
         if (file == default) return;
 
-        var fileInfo = new FileInfo(file.Path.AbsolutePath);
+
+        var absolutePath = HttpUtility.UrlDecode(file.Path.AbsolutePath);
+
+        var fileInfo = new FileInfo(absolutePath);
 
         switch (ViewModel.CurrentUser.IsDonator)
         {
@@ -69,7 +73,7 @@ public partial class EditUserView : ReactiveUserControl<EditUserViewModel>
                 return;
         }
 
-        var picture = await File.ReadAllBytesAsync(file.Path.AbsolutePath);
+        var picture = await File.ReadAllBytesAsync(absolutePath);
 
         await using (var stream = new MemoryStream(picture))
         {

--- a/OsuPlayer/Views/HomeSubViews/HomeUserPanelViewModel.cs
+++ b/OsuPlayer/Views/HomeSubViews/HomeUserPanelViewModel.cs
@@ -110,9 +110,9 @@ public class HomeUserPanelViewModel : BaseViewModel
 
         await _profileManager.Login(sessionToken);
 
+        this.RaisePropertyChanged(nameof(CurrentUser));
         this.RaisePropertyChanged(nameof(IsUserLoggedIn));
         this.RaisePropertyChanged(nameof(IsUserNotLoggedIn));
-        this.RaisePropertyChanged(nameof(CurrentUser));
 
         ProfilePicture = await LoadProfilePictureAsync();
     }

--- a/OsuPlayer/Windows/FluentAppWindow.axaml.cs
+++ b/OsuPlayer/Windows/FluentAppWindow.axaml.cs
@@ -92,8 +92,7 @@ public partial class FluentAppWindow : FluentReactiveWindow<FluentAppWindowViewM
 
             SetRenderMode(config.Container.RenderingMode);
 
-            AppNavigationView.PaneDisplayMode =
-                config.Container.UseLeftNavigationPosition ? NavigationViewPaneDisplayMode.Left : NavigationViewPaneDisplayMode.Top;
+            AppNavigationView.PaneDisplayMode = config.Container.UseLeftNavigationPosition ? NavigationViewPaneDisplayMode.Left : NavigationViewPaneDisplayMode.Top;
 
             var backgroundColor = config.Container.BackgroundColor;
             ViewModel!.DisplayBackgroundImage = config.Container.DisplayBackgroundImage;

--- a/OsuPlayer/Windows/FluentAppWindowViewModel.cs
+++ b/OsuPlayer/Windows/FluentAppWindowViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Reactive.Disposables;
+using System.Runtime.InteropServices;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Threading;
@@ -50,8 +51,8 @@ public class FluentAppWindowViewModel : BaseWindowViewModel
     public bool IsNonLinuxOs { get; }
     public bool IsLinuxOs { get; }
 
-    public bool IsUserLoggedIn => ProfileManager.User != default && ProfileManager.User?.UniqueId != Guid.Empty;
-    public bool IsUserNotLoggedIn => ProfileManager.User == default || ProfileManager.User?.UniqueId == Guid.Empty;
+    public bool IsUserLoggedIn => ProfileManager.User != null && ProfileManager.User?.UniqueId != Guid.Empty;
+    public bool IsUserNotLoggedIn => ProfileManager.User == null || ProfileManager.User?.UniqueId == Guid.Empty;
 
     private ReadOnlyObservableCollection<IMapEntryBase>? _songList;
 
@@ -147,5 +148,15 @@ public class FluentAppWindowViewModel : BaseWindowViewModel
                 BackgroundImage = null;
             });
         }, true, true);
+
+        if (!File.Exists("data/session.op"))
+            return;
+
+        var sessionToken = File.ReadAllText("data/session.op");
+
+        profileManager.Login(sessionToken);
+
+        this.RaisePropertyChanged(nameof(IsUserLoggedIn));
+        this.RaisePropertyChanged(nameof(IsUserNotLoggedIn));
     }
 }


### PR DESCRIPTION
- Fixed a crash when you select a profile picture that has a space in its path/filename
- Also fixes Edit Profile not showing up when the player loads the session from the file